### PR TITLE
FEATURE: Enable sideloading of curated queries from stock_queries.json

### DIFF
--- a/config/stock_queries.json
+++ b/config/stock_queries.json
@@ -1,0 +1,14 @@
+{
+    "queries": [
+      {
+        "sql": "WITH pairs AS (\n    SELECT p.user_id liked, pa.user_id liker\n    FROM post_actions pa\n    LEFT JOIN posts p ON p.id = pa.post_id\n    WHERE post_action_type_id = 2\n)\nSELECT liker liker_user_id, liked liked_user_id, count(*)\nFROM pairs\nGROUP BY liked, liker\nORDER BY count DESC",
+        "name": "Most Common Likers",
+        "description": "Which users like particular other users the most? Query by @riking"
+      },
+      {
+        "sql": "SELECT\n  username\nFROM\n  users\nWHERE\n NOT staged AND active AND last_seen_at IS NOT NULL\n AND\n NOT EXISTS (SELECT 1 FROM facebook_user_infos WHERE facebook_user_infos.user_id = users.id)\n AND\n NOT EXISTS (SELECT 1 FROM github_user_infos WHERE github_user_infos.user_id = users.id)\n AND\n NOT EXISTS (SELECT 1 FROM google_user_infos WHERE google_user_infos.user_id = users.id)\n AND\n NOT EXISTS (SELECT 1 FROM twitter_user_infos WHERE twitter_user_infos.user_id = users.id)\n AND\n NOT EXISTS (SELECT 1 FROM user_open_ids WHERE user_open_ids.user_id = users.id)",
+        "name": "Users without Social Logins",
+        "description": "This query should return users that don't have any Social Logins (Facebook, Twitter, etc.) associated in their accounts."
+      }
+    ]
+}


### PR DESCRIPTION
- [ ] Decide how to make system queries stand out visually
- [ ] Curate a list of ~20 awesome queries from Meta
- [x] Decide appropriate date/year for `query.created_at`

![stock](https://user-images.githubusercontent.com/5862206/45109692-e5c88a00-b15d-11e8-9541-f3de70055e25.png)


**How this works:**
If there are no queries in the DB that have been created by the `system` user, a set of curated queries are imported from config/stock_queries.json.