### PR TITLE
UX: Style improvements in query edit & result view

### DIFF
--- a/assets/javascripts/discourse/controllers/admin-plugins-explorer.js.es6
+++ b/assets/javascripts/discourse/controllers/admin-plugins-explorer.js.es6
@@ -102,6 +102,7 @@ export default Ember.Controller.extend({
       this.setProperties({
         asc: null,
         order: null,
+        showResults: false,
         selectedQueryId: null,
         sortBy: ['last_run_at:desc']
       });
@@ -163,6 +164,7 @@ export default Ember.Controller.extend({
       const self = this;
       const query = this.get('selectedItem');
       this.set('loading', true);
+      this.set('showResults', false);
       this.store.destroyRecord('query', query).then(function() {
         query.set('destroyed', true);
       }).catch(popupAjaxError).finally(function() {
@@ -174,6 +176,7 @@ export default Ember.Controller.extend({
       const self = this;
       const query = this.get('selectedItem');
       this.set('loading', true);
+      this.set('showResults', true);
       query.save().then(function() {
         query.set('destroyed', false);
       }).catch(popupAjaxError).finally(function() {

--- a/assets/javascripts/discourse/templates/explorer-query-result.hbs
+++ b/assets/javascripts/discourse/templates/explorer-query-result.hbs
@@ -1,17 +1,21 @@
 <div class="result-info">
-  {{i18n "explorer.download"}}
   {{d-button action="downloadResultJson" icon="download" label="explorer.download_json"}}
   {{d-button action="downloadResultCsv" icon="download" label="explorer.download_csv"}}
-  <div class="result-about">
-    {{duration}}
-  </div>
 </div>
 
+<div class="result-about">
+  {{duration}}
+</div>
+
+<br>
+
 {{~#if hasExplain}}
-  <pre><code>
+  <pre class="result-explain"><code>
     {{~content.explain}}
   </code></pre>
 {{~/if}}
+
+<br>
 
 <table>
   <thead>

--- a/assets/stylesheets/explorer.scss
+++ b/assets/stylesheets/explorer.scss
@@ -298,6 +298,18 @@
   }
 }
 
+.result-info {
+  float: left;
+}
+.result-about {
+  color: $primary-high;
+  float: right;
+}
+.result-explain {
+  padding-top: 1em;
+  margin-bottom: 0px;
+}
+
 .explorer-pad-bottom {
   margin-bottom: 200px;
 }

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -48,7 +48,6 @@ en:
       edit: "Edit"
       delete: "Delete"
       recover: "Undelete Query"
-      download: "Download Results"
       download_json: "JSON"
       download_csv: "CSV"
       others_dirty: "A query has unsaved changes that will be lost if you navigate away."


### PR DESCRIPTION
- removed 'Download results' text
- improve spacing, alignment and colors for query result page 
- hide query results when query is deleted and when user goes back to query list

## Before

![beforeedit](https://user-images.githubusercontent.com/5862206/45428608-350f3d00-b6bf-11e8-8db7-1aa4674e6fbc.png)

## After
![afterredit](https://user-images.githubusercontent.com/5862206/45428624-3e000e80-b6bf-11e8-8db9-c92273782d3f.png)
