### PR TITLE
FIX: Return all groups instead of truncated list

### DIFF
--- a/assets/javascripts/discourse/controllers/admin-plugins-explorer.js.es6
+++ b/assets/javascripts/discourse/controllers/admin-plugins-explorer.js.es6
@@ -70,7 +70,7 @@ export default Ember.Controller.extend({
 
   @computed("groups")
   groupOptions(groups) {
-    return groups.arrangedContent.map(g => {
+    return groups.map(g => {
       return { id: g.id.toString(), name: g.name };
     });
   },

--- a/assets/javascripts/discourse/routes/admin-plugins-explorer.js.es6
+++ b/assets/javascripts/discourse/routes/admin-plugins-explorer.js.es6
@@ -4,7 +4,7 @@ export default Discourse.Route.extend({
   controllerName: "admin-plugins-explorer",
 
   model() {
-    const groupPromise = this.store.findAll("group");
+    const groupPromise = ajax("/admin/plugins/explorer/groups.json");
     const schemaPromise = ajax("/admin/plugins/explorer/schema.json", {
       cache: true
     });

--- a/plugin.rb
+++ b/plugin.rb
@@ -1032,6 +1032,10 @@ SQL
       render_serialized query, DataExplorer::QuerySerializer, root: 'query'
     end
 
+    def groups
+      render_serialized(Group.all, BasicGroupSerializer)
+    end
+
     def group_reports_index
       return raise Discourse::NotFound unless guardian.user_is_a_member_of_group?(group)
 
@@ -1239,6 +1243,7 @@ SQL
     root to: "query#index"
     get 'schema' => "query#schema"
     get 'queries' => "query#index"
+    get 'groups' => "query#groups"
     post 'queries' => "query#create"
     get 'queries/:id' => "query#show"
     put 'queries/:id' => "query#update"


### PR DESCRIPTION
After investigating a bug where the group list truncates after 30 or so groups, I found the Ember group model calls the `/group/search.json` endpoint, which is what returns the truncated result set. This PR creates a custom endpoint to return all groups to avoid the issue.