### PR TITLE
UX: minor share report popup improvements

### DIFF
--- a/assets/javascripts/discourse/templates/components/share-report.hbs
+++ b/assets/javascripts/discourse/templates/components/share-report.hbs
@@ -6,6 +6,6 @@
   <div class='popup'>
     <label>{{i18n "explorer.link"}} {{group}}</label>
     <input type="text" value={{link}}/>
-    {{d-button action="close" class="btn btn-flat close" icon="times" aria-label="share.close" title="share.close"}}
+    {{d-button action="close" class="btn-flat close" icon="times" aria-label="share.close" title="share.close"}}
   </div>
 {{/if}}

--- a/assets/javascripts/discourse/templates/components/share-report.hbs
+++ b/assets/javascripts/discourse/templates/components/share-report.hbs
@@ -5,9 +5,7 @@
 {{#if visible}}
   <div class='popup'>
     <label>{{i18n "explorer.link"}} {{group}}</label>
-    <input value={{link}}/>
-    <span onclick={{action "close"}}>
-      {{d-icon "times"}}
-    </span>
+    <input type="text" value={{link}}/>
+    {{d-button action="close" class="btn btn-flat close" icon="times" aria-label="share.close" title="share.close"}}
   </div>
 {{/if}}

--- a/assets/stylesheets/explorer.scss
+++ b/assets/stylesheets/explorer.scss
@@ -413,7 +413,7 @@ table.group-reports {
     margin-right: 4px;
   }
   .popup {
-    background: white;
+    background-color: $secondary;
     position: absolute;
     box-shadow: shadow("card");
     padding: 12px;


### PR DESCRIPTION
This change will make sure color schemes are honored, add `type="text"` to the `<input>` element, and reuse the "close" icon button from core's share-link popup.

**Before:**
<img width="315" alt="Screen Shot 2020-05-18 at 4 26 16 PM" src="https://user-images.githubusercontent.com/22733864/82270595-26643900-992a-11ea-97fa-aae74ba721a8.png">


**After:**
<img width="320" alt="Screen Shot 2020-05-18 at 4 26 27 PM" src="https://user-images.githubusercontent.com/22733864/82270438-ad64e180-9929-11ea-96a1-9e83b39df420.png">