### PR TITLE
FIX: missing default params on group reports

### DIFF
--- a/assets/javascripts/discourse/routes/group-reports-show.js.es6
+++ b/assets/javascripts/discourse/routes/group-reports-show.js.es6
@@ -8,8 +8,14 @@ export default DiscourseRoute.extend({
     const group = this.modelFor("group");
     return ajax(`/g/${group.name}/reports/${params.query_id}`)
       .then(response => {
+        const queryParamInfo = response.query.param_info;
+        const queryParams = queryParamInfo.reduce((acc, param) => {
+          acc[param.identifier] = param.default;
+          return acc;
+        }, {});
+
         return {
-          model: Object.assign({ params: {} }, response.query),
+          model: Object.assign({ params: queryParams }, response.query),
           group
         };
       })

--- a/assets/javascripts/discourse/templates/group-reports-index.hbs
+++ b/assets/javascripts/discourse/templates/group-reports-index.hbs
@@ -19,7 +19,11 @@
             {{#link-to 'group.reports.show' group.name query.id}}{{query.name}}{{/link-to}}
           </td>
           <td>{{query.description}}</td>
-          <td>{{bound-date query.last_run_at}}</td>
+          <td>
+            {{#if query.last_run_at}}
+              {{bound-date query.last_run_at}}
+            {{/if}}
+          </td>
         </tr>
       {{/each}}
     </tbody>


### PR DESCRIPTION
This change will ensure that any default values specified in the params list of a Data Explorer query are included when running a query from a group's "Reports" section.

**Before:**
<img width="1180" alt="Screen Shot 2020-05-19 at 3 17 16 PM" src="https://user-images.githubusercontent.com/22733864/82384271-5c65f380-99e4-11ea-98c1-f890c2504d71.png">


**After:**
<img width="1183" alt="Screen Shot 2020-05-19 at 3 17 01 PM" src="https://user-images.githubusercontent.com/22733864/82384268-5a9c3000-99e4-11ea-8360-12dc16f393da.png">

This will also ensure that there are no missing translations displayed in the "Last run" column of the report list when the report has never been run.

**Before:**
<img width="244" alt="Screen Shot 2020-05-19 at 3 19 32 PM" src="https://user-images.githubusercontent.com/22733864/82384323-81f2fd00-99e4-11ea-9810-7f29ab155084.png">


**After:**
<img width="222" alt="Screen Shot 2020-05-19 at 3 20 12 PM" src="https://user-images.githubusercontent.com/22733864/82384332-86b7b100-99e4-11ea-8b79-9d3cb9931f97.png">
