### PR TITLE
FEATURE: Add ability to toggle visibility for individual queries

### DIFF
--- a/assets/javascripts/discourse/controllers/admin-plugins-explorer.js.es6
+++ b/assets/javascripts/discourse/controllers/admin-plugins-explorer.js.es6
@@ -135,7 +135,12 @@ export default Ember.Controller.extend({
     },
 
     toggleQueryVisibility(query) {
-      query.set("is_hidden", !query.is_hidden);
+      const item = this.model.findBy("id", query.id);
+      const isHidden = item.is_hidden == "true";
+
+      isHidden ? item.set("is_hidden", String.valueOf(!isHidden)) : item.set("is_hidden", !isHidden);
+      item.markNotDirty();
+      item.save();
     },
 
     showCreate() {

--- a/assets/javascripts/discourse/controllers/admin-plugins-explorer.js.es6
+++ b/assets/javascripts/discourse/controllers/admin-plugins-explorer.js.es6
@@ -17,6 +17,7 @@ export default Ember.Controller.extend({
   hideSchema: false,
   loading: false,
   explain: false,
+  hiddenQueriesVisible: false,
 
   saveDisabled: Ember.computed.not("selectedItem.dirty"),
   runDisabled: Ember.computed.reads("selectedItem.dirty"),
@@ -127,6 +128,14 @@ export default Ember.Controller.extend({
     importQuery() {
       showModal("import-query");
       this.set("showCreate", false);
+    },
+
+    toggleHiddenQueriesVisibility() {
+      this.toggleProperty("hiddenQueriesVisible");
+    },
+
+    toggleQueryVisibility(query) {
+      query.set("is_hidden", !query.is_hidden);
     },
 
     showCreate() {

--- a/assets/javascripts/discourse/models/query.js.es6
+++ b/assets/javascripts/discourse/models/query.js.es6
@@ -24,7 +24,7 @@ const Query = RestModel.extend({
     this.resetParams();
   },
 
-  @observes("name", "description", "sql", "group_ids", "isHidden")
+  @observes("name", "description", "sql", "group_ids", "is_hidden")
   markDirty() {
     this.set("dirty", true);
   },

--- a/assets/javascripts/discourse/models/query.js.es6
+++ b/assets/javascripts/discourse/models/query.js.es6
@@ -24,7 +24,7 @@ const Query = RestModel.extend({
     this.resetParams();
   },
 
-  @observes("name", "description", "sql", "group_ids")
+  @observes("name", "description", "sql", "group_ids", "isHidden")
   markDirty() {
     this.set("dirty", true);
   },
@@ -85,7 +85,8 @@ Query.reopenClass({
     "created_by",
     "created_at",
     "group_ids",
-    "last_run_at"
+    "last_run_at",
+    "is_hidden"
   ]
 });
 

--- a/assets/javascripts/discourse/templates/admin/plugins-explorer.hbs
+++ b/assets/javascripts/discourse/templates/admin/plugins-explorer.hbs
@@ -167,13 +167,9 @@
     {{#if showRecentQueries}}
       <div class="container">
         {{#if hiddenQueriesVisible}}
-          <div class="buttons">
-            {{d-button label="explorer.query_hidden.all_hide" action=(action "toggleHiddenQueriesVisibility") icon="far-eye-slash"}}
-          </div>
+          {{d-button label="explorer.query_hidden.all_hide" action=(action "toggleHiddenQueriesVisibility") icon="far-eye-slash"}}
         {{else}}
-          <div class="buttons">
-            {{d-button label="explorer.query_hidden.all_show" action=(action "toggleHiddenQueriesVisibility") icon="far-eye"}}
-          </div>
+          {{d-button label="explorer.query_hidden.all_show" action=(action "toggleHiddenQueriesVisibility") icon="far-eye"}}
         {{/if}}
 
         <table class="recent-queries">
@@ -234,9 +230,7 @@
                     {{/if}}
                   </td>
                   <td class="query-hide">
-                    <div class="buttons">
-                      {{d-button label="explorer.query_hidden.query_hide" action=(action "toggleQueryVisibility" query) icon="far-eye-slash"}}
-                    </div>
+                    {{d-button label="explorer.query_hidden.query_hide" action=(action "toggleQueryVisibility" query) icon="far-eye-slash"}}
                   </td>
                 </tr>
               {{else}}
@@ -272,9 +266,7 @@
                       {{/if}}
                     </td>
                     <td class="query-hide">
-                      <div class="buttons">
-                        {{d-button label="explorer.query_hidden.query_show" action=(action "toggleQueryVisibility" query) icon="far-eye"}}
-                      </div>
+                      {{d-button label="explorer.query_hidden.query_show" action=(action "toggleQueryVisibility" query) icon="far-eye"}}
                     </td>
                   </tr>
                 {{/if}}

--- a/assets/javascripts/discourse/templates/admin/plugins-explorer.hbs
+++ b/assets/javascripts/discourse/templates/admin/plugins-explorer.hbs
@@ -166,6 +166,16 @@
 
     {{#if showRecentQueries}}
       <div class="container">
+        {{#if hiddenQueriesVisible}}
+          <div class="buttons">
+            {{d-button label="explorer.query_hidden.all_hide" action=(action "toggleHiddenQueriesVisibility") icon="far-eye-slash"}}
+          </div>
+        {{else}}
+          <div class="buttons">
+            {{d-button label="explorer.query_hidden.all_show" action=(action "toggleHiddenQueriesVisibility") icon="far-eye"}}
+          </div>
+        {{/if}}
+
         <table class="recent-queries">
           <thead class="heading-container">
             <th class="col heading name">
@@ -192,37 +202,83 @@
           <tr></tr>
           <tbody>
             {{#each filteredContent as |query|}}
-              <tr class="query-row">
-                <td>
-                  <a {{action "scrollTop"}} href="/admin/plugins/explorer/?id={{query.id}}">
-                    <b class="query-name">{{query.name}}</b>
-                    <medium class="query-desc">{{query.description}}</medium>
-                  </a>
-                </td>
-                <td class="query-created-by">
-                  {{#if query.username}}
-                    <a href="/users/{{query.username}}/activity">
-                      <medium>{{query.username}}</medium>
+              {{#unless query.is_hidden}}
+                <tr class="query-row">
+                  <td>
+                    <a {{action "scrollTop"}} href="/admin/plugins/explorer/?id={{query.id}}">
+                      <b class="query-name">{{query.name}}</b>
+                      <medium class="query-desc">{{query.description}}</medium>
                     </a>
-                  {{/if}}
-                </td>
-                <td class="query-group-names">
-                  {{#each query.group_names as |group|}}
-                    {{share-report group=group query=query}}
-                  {{/each}}
-                </td>
-                <td class="query-created-at">
-                  {{#if query.last_run_at}}
-                    <medium>
-                      {{bound-date query.last_run_at}}
-                    </medium>
-                  {{else if query.created_at}}
-                    <medium>
-                      {{bound-date query.created_at}}
-                    </medium>
-                  {{/if}}
-                </td>
-              </tr>
+                  </td>
+                  <td class="query-created-by">
+                    {{#if query.username}}
+                      <a href="/users/{{query.username}}/activity">
+                        <medium>{{query.username}}</medium>
+                      </a>
+                    {{/if}}
+                  </td>
+                  <td class="query-group-names">
+                    {{#each query.group_names as |group|}}
+                      {{share-report group=group query=query}}
+                    {{/each}}
+                  </td>
+                  <td class="query-created-at">
+                    {{#if query.last_run_at}}
+                      <medium>
+                        {{bound-date query.last_run_at}}
+                      </medium>
+                    {{else if query.created_at}}
+                      <medium>
+                        {{bound-date query.created_at}}
+                      </medium>
+                    {{/if}}
+                  </td>
+                  <td class="query-hide">
+                    <div class="buttons">
+                      {{d-button label="explorer.query_hidden.query_hide" action=(action "toggleQueryVisibility" query) icon="far-eye-slash"}}
+                    </div>
+                  </td>
+                </tr>
+              {{else}}
+                {{#if hiddenQueriesVisible}}
+                  <tr class="query-row" style="background-color: lightgray;">
+                    <td>
+                      <a {{action "scrollTop"}} href="/admin/plugins/explorer/?id={{query.id}}">
+                        <b class="query-name">{{query.name}}</b>
+                        <medium class="query-desc">{{query.description}}</medium>
+                      </a>
+                    </td>
+                    <td class="query-created-by">
+                      {{#if query.username}}
+                        <a href="/users/{{query.username}}/activity">
+                          <medium>{{query.username}}</medium>
+                        </a>
+                      {{/if}}
+                    </td>
+                    <td class="query-group-names">
+                      {{#each query.group_names as |group|}}
+                        {{share-report group=group query=query}}
+                      {{/each}}
+                    </td>
+                    <td class="query-created-at">
+                      {{#if query.last_run_at}}
+                        <medium>
+                          {{bound-date query.last_run_at}}
+                        </medium>
+                      {{else if query.created_at}}
+                        <medium>
+                          {{bound-date query.created_at}}
+                        </medium>
+                      {{/if}}
+                    </td>
+                    <td class="query-hide">
+                      <div class="buttons">
+                        {{d-button label="explorer.query_hidden.query_show" action=(action "toggleQueryVisibility" query) icon="far-eye"}}
+                      </div>
+                    </td>
+                  </tr>
+                {{/if}}
+              {{/unless}}
             {{else}}
               <br>
               <em class="no-search-results"> {{i18n "explorer.no_search_results"}}</em>

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -72,6 +72,11 @@ en:
       reset_params: "Reset"
       search_placeholder: "Search..."
       no_search_results: "Sorry, we couldn't find any results matching your text."
+      query_hidden: 
+        query_show: "Show"
+        query_hide: "Hide"
+        all_show: "Show Hidden Queries"
+        all_hide: "Hide Hidden Queries"
     group:
       reports: "Reports"
 

--- a/plugin.rb
+++ b/plugin.rb
@@ -641,7 +641,6 @@ SQL
       @description = ''
       @sql = 'SELECT 1'
       @group_ids = []
-      @is_hidden = false
     end
 
     def slug
@@ -1038,7 +1037,6 @@ SQL
         query.name = params.second["name"]
         query.description = params.second["description"]
         query.created_by = Discourse::SYSTEM_USER_ID.to_s
-        query.is_hidden = false
 
         # don't render this query if query with the same id already exists in pstore
         queries.push(query) unless DataExplorer.pstore_get("q:#{query.id}").present?
@@ -1105,7 +1103,6 @@ SQL
       query.created_by = current_user.id.to_s
       query.last_run_at = Time.now
       query.id = nil # json import will assign an id, which is wrong
-      query.is_hidden = false
       query.save
 
       render_serialized query, DataExplorer::QuerySerializer, root: 'query'


### PR DESCRIPTION
- User can click the hide/show button to toggle the query's visibility
- When the Hide/Show Hidden Queries button is toggled, it will
    - Show hidden queries with gray background when on
    - Hide hidden queries when off
- Visibility state of each query is persisted upon page refresh

![discourse-data-explorer-hide](https://user-images.githubusercontent.com/24194862/87233998-cecad280-c39a-11ea-88df-015964c98dfd.gif)