### PR TITLE
FIX: Use updated routes to link user profiles

### DIFF
--- a/assets/javascripts/discourse/templates/admin/plugins-explorer.hbs
+++ b/assets/javascripts/discourse/templates/admin/plugins-explorer.hbs
@@ -201,7 +201,7 @@
                 </td>
                 <td class="query-created-by">
                   {{#if query.username}}
-                    <a href="/users/{{query.username}}/activity">
+                    <a href="/u/{{query.username}}/activity">
                       <medium>{{query.username}}</medium>
                     </a>
                   {{/if}}

--- a/assets/javascripts/discourse/templates/explorer/user.raw.hbs
+++ b/assets/javascripts/discourse/templates/explorer/user.raw.hbs
@@ -1,5 +1,5 @@
 {{#if user}}
-  <a href="{{baseuri}}/users/{{user.username}}/activity"
+  <a href="{{baseuri}}/u/{{user.username}}/activity"
      data-user-card="{{user.username}}">{{avatar user imageSize="tiny"}} {{user.username}}</a>
 {{else}}
   {{id}}


### PR DESCRIPTION
This fixes links for both, the result view:

![image](https://user-images.githubusercontent.com/5862206/90391427-c1e08380-e0aa-11ea-916c-6d0056b312de.png)

and the query view:

![image](https://user-images.githubusercontent.com/5862206/90391480-d45abd00-e0aa-11ea-8f6f-9f3bd02d5f87.png)

