### PR TITLE
UX: Make group report index styling more consistent with core

### DIFF
--- a/assets/stylesheets/explorer.scss
+++ b/assets/stylesheets/explorer.scss
@@ -12,24 +12,13 @@ table.group-reports {
     width: 20%;
     text-align: right;
   }
-  tbody {
-    border-top: 3px solid #e3ebf2;
-
-    tr {
-      border-bottom: 1px solid #e3ebf2;
-
-      td {
-        color: #7499bd;
-        padding: 0.8em 0.5em;
-      }
-
-      td:first-child {
-        font-size: 16px;
-      }
-
-      td:last-child {
-        text-align: right;
-      }
+  tbody tr td {
+    padding: 0.5em;
+    &:first-child {
+      font-size: $font-up-1;
+    }
+    &:last-child {
+      text-align: right;
     }
   }
 }


### PR DESCRIPTION
We probably don't want to use hard-coded colors here to ensure as much theme compatibility as possible. Also tightened up the padding a little bit and switched the font-sizing over to a variable.

### Before
<img width="400" alt="before" src="https://user-images.githubusercontent.com/22733864/95523036-78156a80-0982-11eb-8423-6fec2db17e68.png"><img width="400" alt="before2" src="https://user-images.githubusercontent.com/22733864/95523318-29b49b80-0983-11eb-9382-589ff438f5e2.png">


### After
<img width="400" alt="after" src="https://user-images.githubusercontent.com/22733864/95523046-7cda1e80-0982-11eb-8e6e-1c74606deabb.png"><img width="400" alt="after2" src="https://user-images.githubusercontent.com/22733864/95523328-333e0380-0983-11eb-83d2-ddbd123abebe.png">

