### PR TITLE
FIX: flaky fix_query_id_spec because id conflict

### DIFF
--- a/spec/lib/tasks/fix_query_ids_spec.rb
+++ b/spec/lib/tasks/fix_query_ids_spec.rb
@@ -133,6 +133,7 @@ describe 'fix query ids rake task' do
 
   def attributes(name)
     {
+      id: DataExplorer::Query.count == 0 ? 5 : DataExplorer::Query.maximum(:id) + 1,
       name: name,
       description: 'A Query',
       sql: "SELECT 1",


### PR DESCRIPTION
This rake task is responsible for fixing broken ids - move them back to the original values - ones before migration to a separate table.

Rake task can only fix queries with unique names.

In the test, we are creating duplicated queries and using `original_id` 4. Spec is ensuring that after rake tasks valuation, queries id is different than `4`

However, spec run in random order may create a query with id 4 and in that case, the spec would fail.

Therefore, when we create queries for test purpose, we should control what ids they are given to avoid conflict.