### PR TITLE
FIX: Permitted groups should display on group query access picker

### DIFF
--- a/assets/javascripts/discourse/controllers/admin-plugins-explorer.js.es6
+++ b/assets/javascripts/discourse/controllers/admin-plugins-explorer.js.es6
@@ -70,7 +70,7 @@ export default Ember.Controller.extend({
     return groups
       .filter((g) => g.id !== 0)
       .map((g) => {
-        return { id: g.id.toString(), name: g.name };
+        return { id: g.id, name: g.name };
       });
   },
 


### PR DESCRIPTION
The `toString()` that was introduced in https://github.com/discourse/discourse-data-explorer/commit/80ffc4582f097ebdc0be426c78233f038a1eabcd was preventing any actively permitted groups from displaying in the group picker when entering a query page.