### PR TITLE
FEATURE: destroy old hidden queries

### DIFF
--- a/app/jobs/scheduled/delete_hidden_queries.rb
+++ b/app/jobs/scheduled/delete_hidden_queries.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Jobs
+  class DeleteHiddenQueries < ::Jobs::Scheduled
+    every 7.days
+
+    def execute(args)
+      return unless SiteSetting.data_explorer_enabled
+
+      DataExplorer::Query.where("id > 0")
+        .where(hidden: true)
+        .where("(last_run_at IS NULL OR last_run_at < :days_ago) AND updated_at < :days_ago", days_ago: 7.days.ago)
+        .delete_all
+    end
+  end
+end

--- a/spec/jobs/scheduled/delete_hidden_queries_spec.rb
+++ b/spec/jobs/scheduled/delete_hidden_queries_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe Jobs::DeleteHiddenQueries do
+  before do
+    Jobs.run_immediately!
+    SiteSetting.data_explorer_enabled = true
+  end
+
+  it "will correctly destroy old hidden queries" do
+    DataExplorer::Query.create!(id: 1, name: "A", description: "A description for A", sql: "SELECT 1 as value", hidden: false, last_run_at: 2.days.ago, updated_at: 2.days.ago)
+    DataExplorer::Query.create!(id: 2, name: "B", description: "A description for B", sql: "SELECT 1 as value", hidden: true, last_run_at: 8.days.ago, updated_at: 8.days.ago)
+    DataExplorer::Query.create!(id: 3, name: "C", description: "A description for C", sql: "SELECT 1 as value", hidden: true, last_run_at: 4.days.ago, updated_at: 4.days.ago)
+    DataExplorer::Query.create!(id: 4, name: "D", description: "A description for D", sql: "SELECT 1 as value", hidden: true, last_run_at: nil, updated_at: 10.days.ago)
+    DataExplorer::Query.create!(id: 5, name: "E", description: "A description for E", sql: "SELECT 1 as value", hidden: true, last_run_at: 5.days.ago, updated_at: 10.days.ago)
+    DataExplorer::Query.create!(id: 6, name: "F", description: "A description for F", sql: "SELECT 1 as value", hidden: true, last_run_at: 10.days.ago, updated_at: 5.days.ago)
+
+    subject.execute(nil)
+    expect(DataExplorer::Query.all.length).to eq(4)
+  end
+end


### PR DESCRIPTION
This commit adds a scheduled job to hard delete queries that are hidden and

- were last run more than 7 days ago
- were updated more than 7 days ago