### PR TITLE
FIX: Use standard error handling for requests, special-case moderators

### DIFF
--- a/assets/javascripts/discourse/routes/admin-plugins-explorer.js.es6
+++ b/assets/javascripts/discourse/routes/admin-plugins-explorer.js.es6
@@ -17,25 +17,24 @@ export default DiscourseRoute.extend({
     });
     const queryPromise = this.store.findAll("query");
 
-    return groupPromise
-      .then((groups) => {
-        let groupNames = {};
-        groups.forEach((g) => {
-          groupNames[g.id] = g.name;
-        });
-        return schemaPromise.then((schema) => {
-          return queryPromise.then((model) => {
-            model.forEach((query) => {
-              query.markNotDirty();
-              query.set(
-                "group_names",
-                (query.group_ids || []).map((id) => groupNames[id])
-              );
-            });
-            return { model, schema, groups };
+    return groupPromise.then((groups) => {
+      let groupNames = {};
+      groups.forEach((g) => {
+        groupNames[g.id] = g.name;
+      });
+      return schemaPromise.then((schema) => {
+        return queryPromise.then((model) => {
+          model.forEach((query) => {
+            query.markNotDirty();
+            query.set(
+              "group_names",
+              (query.group_ids || []).map((id) => groupNames[id])
+            );
           });
+          return { model, schema, groups };
         });
       });
+    });
   },
 
   setupController(controller, model) {

--- a/assets/javascripts/discourse/routes/admin-plugins-explorer.js.es6
+++ b/assets/javascripts/discourse/routes/admin-plugins-explorer.js.es6
@@ -1,10 +1,16 @@
 import { ajax } from "discourse/lib/ajax";
+import User from "discourse/models/user";
 import DiscourseRoute from "discourse/routes/discourse";
 
 export default DiscourseRoute.extend({
   controllerName: "admin-plugins-explorer",
 
   model() {
+    if (!User.currentProp("admin")) {
+      // display "Only available to admins" message
+      return { model: null, schema: null, disallow: true, groups: null };
+    }
+
     const groupPromise = ajax("/admin/plugins/explorer/groups.json");
     const schemaPromise = ajax("/admin/plugins/explorer/schema.json", {
       cache: true,
@@ -29,11 +35,6 @@ export default DiscourseRoute.extend({
             return { model, schema, groups };
           });
         });
-      })
-      .catch(() => {
-        schemaPromise.catch(() => {});
-        queryPromise.catch(() => {});
-        return { model: null, schema: null, disallow: true, groups: null };
       });
   },
 


### PR DESCRIPTION
By removing the catch and letting the error propagate to the top-level error handler, we can receive more detailed error reports including exactly which request failed.

The assumption that any request failure is a permissions error is replaced by an explicit client-side check before making any requests.