### PR TITLE
UX: allow horizontal overflow scroll, fix button

### DIFF
--- a/assets/javascripts/discourse/templates/explorer-query-result.hbs
+++ b/assets/javascripts/discourse/templates/explorer-query-result.hbs
@@ -1,37 +1,43 @@
-<div class="result-info">
-  {{d-button action=(action "downloadResultJson") icon="download" label="explorer.download_json" group=group}}
-  {{d-button action=(action "downloadResultCsv") icon="download" label="explorer.download_csv" group=group}}
-</div>
+<article>
+  <header class="result-header">
+    <div class="result-info">
+      {{d-button action=(action "downloadResultJson") icon="download" label="explorer.download_json" group=group}}
+      {{d-button action=(action "downloadResultCsv") icon="download" label="explorer.download_csv" group=group}}
+    </div>
 
-<div class="result-about">
-  {{resultCount}}
-  {{duration}}
-</div>
+    <div class="result-about">
+      {{resultCount}}
+      {{duration}}
+    </div>
 
-<br>
+    <br>
 
-{{~#if hasExplain}}
-  <pre class="result-explain"><code>
-    {{~content.explain}}
-  </code></pre>
-{{~/if}}
+    {{~#if hasExplain}}
+      <pre class="result-explain"><code>
+        {{~content.explain}}
+      </code></pre>
+    {{~/if}}
 
-<br>
+    <br>
+  </header>
 
-<table>
-  <thead>
-  <tr class="headers">
-    {{#each columnDispNames as |col|}}
-      <th>{{col}}</th>
-    {{/each}}
-  </tr>
-  </thead>
-  <tbody>
-  {{#each rows as |row|}}
-    {{query-row-content
-      row=row
-      fallbackTemplate=fallbackTemplate
-      columnTemplates=columnTemplates}}
-  {{/each}}
-  </tbody>
-</table>
+  <section>
+    <table>
+      <thead>
+      <tr class="headers">
+        {{#each columnDispNames as |col|}}
+          <th>{{col}}</th>
+        {{/each}}
+      </tr>
+      </thead>
+      <tbody>
+      {{#each rows as |row|}}
+        {{query-row-content
+          row=row
+          fallbackTemplate=fallbackTemplate
+          columnTemplates=columnTemplates}}
+      {{/each}}
+      </tbody>
+    </table>
+  </section>
+</article>

--- a/assets/stylesheets/explorer.scss
+++ b/assets/stylesheets/explorer.scss
@@ -280,7 +280,19 @@ table.group-reports {
   margin: 10px 0;
 }
 
+.query-create {
+  display: flex;
+  input {
+    margin-right: 0.5em;
+    margin-bottom: 0;
+  }
+}
+
 .query-results {
+  section {
+    width: 100%;
+    overflow-x: auto;
+  }
   table {
     width: 100%;
     margin-top: 10px;


### PR DESCRIPTION
Structured the results so the table can scroll horizontally independent of the buttons in the header (the export buttons and result meta) and without scrolling the whole page. 

Also fixed a minor button alignment issue when creating new queries. 