### PR TITLE
FIX: Use Ember's debounce on stable.

### DIFF
--- a/assets/javascripts/discourse/components/explorer-schema.js.es6
+++ b/assets/javascripts/discourse/components/explorer-schema.js.es6
@@ -2,8 +2,7 @@ import {
   default as computed,
   observes,
 } from "discourse-common/utils/decorators";
-import discourseDebounce from "discourse-common/lib/debounce";
-import debounce from "@ember/runloop";
+import { debounce } from "@ember/runloop";
 
 export default Ember.Component.extend({
   actions: {
@@ -116,7 +115,11 @@ export default Ember.Component.extend({
   @observes("filter")
   triggerFilter() {
     // TODO: Use discouseDebounce after the 2.7 release.
-    let debounceFunc = discourseDebounce || debounce;
+    let debounceFunc = debounce;
+
+    try {
+      debounceFunc = require("discourse-common/lib/debounce").default;
+    } catch (_) {}
 
     debounceFunc(
       this,


### PR DESCRIPTION
We need to wrap the new debounce function inside a try block to avoid throwing a "module not found" exception.