### PR TITLE
FIX: bump plugin version to 0.3

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -2,7 +2,7 @@
 
 # name: discourse-data-explorer
 # about: Interface for running analysis SQL queries on the live database
-# version: 0.2
+# version: 0.3
 # authors: Riking
 # url: https://github.com/discourse/discourse-data-explorer
 


### PR DESCRIPTION
We have a user [report](https://meta.discourse.org/t/data-explorer-editing-broken-on-stable/181274/3) about the bug that was already fixed (#96). Probably it's some upgrading issue. I want to bump the version to be sure that the plugin's updated.