### PR TITLE
Allow admins to see the group reports nav item

### DIFF
--- a/assets/javascripts/discourse/components/group-reports-nav-item.js.es6
+++ b/assets/javascripts/discourse/components/group-reports-nav-item.js.es6
@@ -13,7 +13,10 @@ export default Ember.Component.extend({
   init(args) {
     this.set("group", args.group);
     if (
-      (this.get("currentUser.groups") || []).some((g) => g.id === this.group.id) || this.get("currentUser.admin")
+      (this.get("currentUser.groups") || []).some(
+        (g) => g.id === this.group.id
+      ) ||
+      this.get("currentUser.admin")
     ) {
       // User is a part of the group (or an admin). Now check if the group has reports
       this.checkForReports();

--- a/assets/javascripts/discourse/components/group-reports-nav-item.js.es6
+++ b/assets/javascripts/discourse/components/group-reports-nav-item.js.es6
@@ -13,9 +13,9 @@ export default Ember.Component.extend({
   init(args) {
     this.set("group", args.group);
     if (
-      (this.get("currentUser.groups") || []).some((g) => g.id === this.group.id)
+      (this.get("currentUser.groups") || []).some((g) => g.id === this.group.id) || this.get("currentUser.admin")
     ) {
-      // User is a part of the group. Now check if the group has reports
+      // User is a part of the group (or an admin). Now check if the group has reports
       this.checkForReports();
     }
 


### PR DESCRIPTION
Previously, the report tab would appear only if the user was a member of the group. With this change, admins can see the reports in any group.