### PR TITLE
DEV: Remove String.endsWith polyfill

### DIFF
--- a/assets/javascripts/discourse/initializers/initialize-data-explorer.js.es6
+++ b/assets/javascripts/discourse/initializers/initialize-data-explorer.js.es6
@@ -2,18 +2,5 @@ export default {
   name: "initialize-data-explorer",
   initialize(container) {
     container.lookup("store:main").addPluralization("query", "queries");
-
-    if (!String.prototype.endsWith) {
-      // eslint-disable-next-line no-extend-native
-      String.prototype.endsWith = function (searchString, position) {
-        const subjectString = this.toString();
-        if (position === undefined || position > subjectString.length) {
-          position = subjectString.length;
-        }
-        position -= searchString.length;
-        const lastIndex = subjectString.indexOf(searchString, position);
-        return lastIndex !== -1 && lastIndex === position;
-      };
-    }
   },
 };


### PR DESCRIPTION
Discourse no longer supports internet explorer. This function is supported natively on all browsers Discourse currently targets.