### PR TITLE
DEV: Run rubocop, prettier and eslint before commit using lefthook

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,5 @@
 GEM
+  remote: https://rubygems.org/
   specs:
     ast (2.4.0)
     jaro_winkler (1.5.4)
@@ -30,4 +31,4 @@ DEPENDENCIES
   rubocop-discourse
 
 BUNDLED WITH
-   2.1.4
+   2.2.7

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,14 @@
+pre-commit:
+  parallel: true
+  commands:
+    rubocop:
+      glob: "*.rb"
+      run: bundle exec rubocop --parallel {staged_files}
+    prettier:
+      glob: "*.{scss,js,es6}"
+      include: "test/javascripts|assets/javascripts"
+      run: yarn prettier --list-different {staged_files}
+    eslint-js:
+      glob: "*.{js,es6}"
+      include: "test/javascripts|assets/javascripts"
+      run: yarn eslint --no-error-on-unmatched-pattern -f compact {staged_files}

--- a/package.json
+++ b/package.json
@@ -1,5 +1,8 @@
 {
   "dependencies": {
     "eslint-config-discourse": "^1.1.8"
+  },
+  "devDependencies": {
+    "@arkweid/lefthook": "^0.7.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,11 @@
 # yarn lockfile v1
 
 
+"@arkweid/lefthook@^0.7.2":
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/@arkweid/lefthook/-/lefthook-0.7.2.tgz#ce2ee89f32bd8899bfee1a61d1fbe68a7dee7601"
+  integrity sha512-r34fl/qiny7564aL+MLmkVbUMjr39vSqSGvUoA7e3FwpvD/ubJkxdDFCDJECvOYiYMXwwaqJc6txXtfnvDY3YQ==
+
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.10.4.tgz#168da1a36e90da68ae8d49c0f1b48c7c6249213a"


### PR DESCRIPTION
To set up in a local repository `yarn run lefthook install` [should be run](https://meta.discourse.org/t/automatically-lint-format-code-before-commits/132947).