### PR TITLE
FIX: back button

### DIFF
--- a/assets/javascripts/discourse/controllers/admin-plugins-explorer.js.es6
+++ b/assets/javascripts/discourse/controllers/admin-plugins-explorer.js.es6
@@ -155,8 +155,7 @@ export default Ember.Controller.extend({
         selectedQueryId: null,
         sortBy: ["last_run_at:desc"],
       });
-      this.send("refreshModel");
-      this.transitionToRoute("adminPlugins.explorer");
+      this.transitionToRoute({ queryParams: { id: null } });
     },
 
     showHelpModal() {

--- a/assets/javascripts/discourse/routes/admin-plugins-explorer.js.es6
+++ b/assets/javascripts/discourse/routes/admin-plugins-explorer.js.es6
@@ -40,11 +40,4 @@ export default DiscourseRoute.extend({
   setupController(controller, model) {
     controller.setProperties(model);
   },
-
-  actions: {
-    refreshModel() {
-      this.refresh();
-      return false;
-    },
-  },
 });


### PR DESCRIPTION
Back button wasn't working when running in Ember CLI:

<img width="400" alt="Screenshot 2021-08-10 at 20 04 31" src="https://user-images.githubusercontent.com/1274517/128911922-8b1fc9fe-56dd-423b-953f-cc8e8f2ec07d.png">

This PR fixes it by doing the transition to the same route but without URL parameter in a [proper way](https://guides.emberjs.com/v3.12.0/routing/query-params/#toc_transitionto). This works in both our environments (legacy-3.12.0, and ember-cli-3.15.0).

I wanted to go further and start using a [full transition](https://guides.emberjs.com/v3.12.0/routing/query-params/#toc_opting-into-a-full-transition) by adding this to the route:
```javascript
queryParams: { 
    filter: { 
        refreshModel: true
    }
},
```
This way `goHome` method could be much simpler:
``` javascript
    goHome() {
      /* we'd remove setting properties then
      this.setProperties({
        asc: null,
        order: null,
        showResults: false,
        editDisabled: false,
        selectedQueryId: null,
        sortBy: ["last_run_at:desc"],
      });
     */ 
      this.transitionToRoute({ queryParams: { id: null } });
    },
```

Unfortunately, this controller is quite fragile and this breaks another transition. I feel like it's better to leave it as is by now, but I'm going to address this some day later.
