### PR TITLE
DEV: Don't explicitly load files

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -34,12 +34,6 @@ module ::DataExplorer
 end
 
 after_initialize do
-  load File.expand_path('../app/models/data_explorer/query.rb', __FILE__)
-  load File.expand_path('../app/controllers/data_explorer/query_controller.rb', __FILE__)
-  load File.expand_path('../app/serializers/data_explorer/query_serializer.rb', __FILE__)
-  load File.expand_path('../app/serializers/data_explorer/small_badge_serializer.rb', __FILE__)
-  load File.expand_path('../app/serializers/data_explorer/small_post_with_excerpt_serializer.rb', __FILE__)
-
   add_to_class(:guardian, :user_is_a_member_of_group?) do |group|
     return false if !current_user
     return true if current_user.admin?


### PR DESCRIPTION
1. It doesn't seem to be necessary?
2. It looks like it was triggering some warnings (`Creating scope :for_group. Overwriting existing method DataExplorer::Query.for_group.`)