### PR TITLE
FEATURE: Move query limit to hidden site setting

### DIFF
--- a/app/controllers/data_explorer/query_controller.rb
+++ b/app/controllers/data_explorer/query_controller.rb
@@ -181,7 +181,7 @@ class DataExplorer::QueryController < ::ApplicationController
             result_count: pg_result.values.length || 0,
             params: query_params,
             columns: cols,
-            default_limit: DataExplorer::QUERY_RESULT_DEFAULT_LIMIT
+            default_limit: SiteSetting.data_explorer_query_result_limit
           }
           json[:explain] = result[:explain] if opts[:explain]
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -2,3 +2,7 @@ plugins:
   data_explorer_enabled:
     default: false
     client: true
+  data_explorer_query_result_limit:
+    default: 1000
+    hidden: true
+    max: 10000

--- a/plugin.rb
+++ b/plugin.rb
@@ -25,7 +25,8 @@ end
 add_admin_route 'explorer.title', 'explorer'
 
 module ::DataExplorer
-  QUERY_RESULT_DEFAULT_LIMIT = 1000
+  # This should always match the max value for the data_explorer_query_result_limit
+  # site setting.
   QUERY_RESULT_MAX_LIMIT = 10000
 
   def self.plugin_name
@@ -117,7 +118,7 @@ after_initialize do
 WITH query AS (
 #{query.sql}
 ) SELECT * FROM query
-LIMIT #{opts[:limit] || DataExplorer::QUERY_RESULT_DEFAULT_LIMIT}
+LIMIT #{opts[:limit] || SiteSetting.data_explorer_query_result_limit}
 SQL
 
           time_start = Time.now


### PR DESCRIPTION
Previously the `QUERY_RESULT_DEFAULT_LIMIT` const was used
to limit the number of query results. This commit adds the
`data_explorer_query_result_limit` site setting which defaults
to 1000 and has a max of 10000 which matches the const
`QUERY_RESULT_MAX_LIMIT`.