### PR TITLE
DEV: Remove 'capitalize' string prototype extensions

### DIFF
--- a/assets/javascripts/discourse/components/query-result.js
+++ b/assets/javascripts/discourse/components/query-result.js
@@ -4,6 +4,7 @@ import { ajax } from "discourse/lib/ajax";
 import getURL from "discourse-common/lib/get-url";
 import Badge from "discourse/models/badge";
 import { default as computed } from "discourse-common/utils/decorators";
+import { capitalize } from "@ember/string";
 
 function randomIdShort() {
   return "xxxxxxxx".replace(/[xy]/g, () => {
@@ -157,7 +158,7 @@ const QueryResultComponent = Ember.Component.extend({
     const relationName = colRender[0];
 
     if (relationName) {
-      const lookupFunc = this[`lookup${relationName.capitalize()}`];
+      const lookupFunc = this[`lookup${capitalize(relationName)}`];
       const labelSelector = labelSelectors[relationName];
 
       if (lookupFunc && labelSelector) {

--- a/assets/javascripts/discourse/components/query-row-content.js
+++ b/assets/javascripts/discourse/components/query-row-content.js
@@ -3,6 +3,7 @@ import { categoryLinkHTML } from "discourse/helpers/category-link";
 import { autoUpdatingRelativeAge } from "discourse/lib/formatter";
 import { convertIconClass, iconHTML } from "discourse-common/lib/icon-library";
 import getURL from "discourse-common/lib/get-url";
+import { capitalize } from "@ember/string";
 
 function icon_or_image_replacement(str, ctx) {
   str = Ember.get(ctx.contexts[0], str);
@@ -79,7 +80,7 @@ const QueryRowContentComponent = Ember.Component.extend({
         return esc(row[idx]);
       }
 
-      const lookupFunc = parentView[`lookup${t.name.capitalize()}`];
+      const lookupFunc = parentView[`lookup${capitalize(t.name)}`];
       if (lookupFunc) {
         ctx[t.name] = lookupFunc.call(parentView, id);
       }


### PR DESCRIPTION
## Ember upgrade

Context: https://deprecations.emberjs.com/v3.x/#toc_ember-string-prototype_extensions