### PR TITLE
UX: Making the headers of the query results table sticky

### DIFF
--- a/assets/stylesheets/explorer.scss
+++ b/assets/stylesheets/explorer.scss
@@ -289,13 +289,22 @@ table.group-reports {
 .query-results {
   section {
     width: 100%;
-    overflow-x: auto;
+    overflow: auto;
+    height: 1000px;
   }
   table {
     width: 100%;
     margin-top: 10px;
     td {
       padding: 8px;
+    }
+  }
+  thead {
+    th {
+      position: sticky;
+      top: 0;
+      color: var(--primary);
+      background: var(--primary-low);
     }
   }
 }


### PR DESCRIPTION
Making the headers sticky, so it's easier to navigate through large query results and match a column with its header.

![Screen Shot 2022-07-06 at 12 17 27](https://user-images.githubusercontent.com/24628951/177597632-befa8018-6e9f-4192-893f-2f2191d6c351.png)

