### PR TITLE
FIX: fixed the blueing of the bookmark icon

### DIFF
--- a/assets/javascripts/discourse/controllers/group-reports-show.js
+++ b/assets/javascripts/discourse/controllers/group-reports-show.js
@@ -86,7 +86,7 @@ export default Controller.extend({
   @discourseComputed("queryGroup.bookmark")
   bookmarkClassName(bookmark) {
     return bookmark
-      ? ["bookmark", "bookmarked", "query-group-bookmark"].join(" ")
-      : ["bookmark", "query-group-bookmark"].join(" ");
+      ? ["query-group-bookmark", "bookmarked"].join(" ")
+      : "query-group-bookmark";
   },
 });

--- a/assets/stylesheets/explorer.scss
+++ b/assets/stylesheets/explorer.scss
@@ -447,7 +447,7 @@ table.group-reports {
 }
 
 .query-group-bookmark {
-  &.bookmark .d-icon {
+  &.bookmarked .d-icon {
     color: var(--tertiary);
   }
 }


### PR DESCRIPTION
Fixed so that the color of the bookmark icon matches other bookmarkables, i.e. blue only when a bookmark exists.