### PR TITLE
FIX: Click not opening query

### DIFF
--- a/assets/javascripts/discourse/controllers/admin-plugins-explorer.js
+++ b/assets/javascripts/discourse/controllers/admin-plugins-explorer.js
@@ -3,7 +3,10 @@ import showModal from "discourse/lib/show-modal";
 import Query from "discourse/plugins/discourse-data-explorer/discourse/models/query";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import { ajax } from "discourse/lib/ajax";
-import discourseComputed, { observes } from "discourse-common/utils/decorators";
+import discourseComputed, {
+  bind,
+  observes,
+} from "discourse-common/utils/decorators";
 import I18n from "I18n";
 import { Promise } from "rsvp";
 import { inject as service } from "@ember/service";
@@ -165,6 +168,12 @@ export default Controller.extend({
     });
   },
 
+  @bind
+  scrollTop() {
+    window.scrollTo(0, 0);
+    this.setProperties({ editing: false, everEditing: false });
+  },
+
   actions: {
     dummy() {},
 
@@ -205,11 +214,6 @@ export default Controller.extend({
 
     download() {
       window.open(this.get("selectedItem.downloadUrl"), "_blank");
-    },
-
-    scrollTop() {
-      window.scrollTo(0, 0);
-      this.setProperties({ editing: false, everEditing: false });
     },
 
     goHome() {

--- a/assets/javascripts/discourse/templates/admin/plugins-explorer.hbs
+++ b/assets/javascripts/discourse/templates/admin/plugins-explorer.hbs
@@ -346,7 +346,7 @@
                 <tr class="query-row">
                   <td>
                     <a
-                      {{action "scrollTop"}}
+                      {{on "click" this.scrollTop}}
                       href="/admin/plugins/explorer/?id={{query.id}}"
                     >
                       <b class="query-name">{{query.name}}</b>


### PR DESCRIPTION
Due to recent core changes for Ember in
https://github.com/discourse/discourse/commit/0221855ba783c6d96d2dbf2ec9f7e92b5297499b and https://github.com/discourse/discourse/commit/952b033165c2b77872d8cc79b0678dc4293c5ee1 the correct way of calling these actions must be observed, otherwise clicking on a query did nothing.

This commit fixes the click and also makes scrollTop work with the new {{on X}} Ember syntax.