### PR TITLE
Hotfix category_id lookup

### DIFF
--- a/assets/javascripts/discourse/components/query-result.js
+++ b/assets/javascripts/discourse/components/query-result.js
@@ -193,7 +193,7 @@ const QueryResultComponent = Component.extend({
   },
 
   lookupCategory(id) {
-    return this.site.get("categoriesById")[id];
+    return this.site.categoriesById[id];
   },
 
   download_url() {

--- a/assets/javascripts/discourse/templates/explorer-query-result.hbs
+++ b/assets/javascripts/discourse/templates/explorer-query-result.hbs
@@ -83,6 +83,7 @@
               @transformedUserTable={{this.transformedUserTable}}
               @transformedGroupTable={{this.transformedGroupTable}}
               @transformedTopicTable={{this.transformedTopicTable}}
+              @site={{this.site}}
             />
           {{/each}}
         </tbody>


### PR DESCRIPTION
https://github.com/discourse/discourse-data-explorer/blob/74dfc39530201ea2afc9b7bb8e43d109e5752514/assets/javascripts/discourse/components/query-row-content.js#L34-L35

needed to pass the site object to 'lookup' parent functions and was erroring on category lookup.

