### PR TITLE
DEV: Better handling of no results

### DIFF
--- a/assets/javascripts/discourse/components/query-result.js
+++ b/assets/javascripts/discourse/components/query-result.js
@@ -126,7 +126,7 @@ export default class QueryResult extends Component {
   get canShowChart() {
     const hasTwoColumns = this.colCount === 2;
     const secondColumnContainsNumber =
-      this.resultCount.length && typeof this.rows[0][1] === "number";
+      this.resultCount[0] > 0 && typeof this.rows[0][1] === "number";
     const secondColumnContainsId = this.colRender[1];
 
     return (

--- a/test/javascripts/integration/components/query-result-test.js
+++ b/test/javascripts/integration/components/query-result-test.js
@@ -326,5 +326,23 @@ discourseModule(
         },
       }
     );
+
+    componentTest("it handles no results", {
+      template: hbs`<QueryResult @content={{content}} />`,
+
+      beforeEach() {
+        const results = {
+          colrender: [],
+          result_count: 0,
+          columns: ["user_name", "like_count", "post_count"],
+          rows: [],
+        };
+        this.set("content", results);
+      },
+
+      test(assert) {
+        assert.ok(!exists("table tbody tr"), "renders no results");
+      },
+    });
   }
 );


### PR DESCRIPTION
When there were no query results it would throw an error due to `this.resultCount` always passing as it is in the format of

```
"INTEGER - results returned"
```

so we need to grab the first index of the string and check if the integer is great than 0