### PR TITLE
DEV: Update params to use previously ran values on reload

### DIFF
--- a/assets/javascripts/discourse/components/param-input.js
+++ b/assets/javascripts/discourse/components/param-input.js
@@ -52,14 +52,20 @@ export default class ParamInput extends Component {
       if (this.type === "boolean") {
         if (this.args.info.nullable) {
           this.nullableBoolValue = initialValue;
+          this.args.updateParams(
+            this.args.info.identifier,
+            this.nullableBoolValue
+          );
         } else {
           this.boolValue = initialValue !== "false";
+          this.args.updateParams(this.args.info.identifier, this.boolValue);
         }
       } else {
         this.value =
           this.args.info.type === "category_id"
             ? this.dasherizeCategoryId(initialValue)
             : initialValue;
+        this.args.updateParams(this.args.info.identifier, this.value);
       }
     } else {
       // if no parsed params then get and set default values

--- a/test/javascripts/acceptance/param-input-test.js
+++ b/test/javascripts/acceptance/param-input-test.js
@@ -1,20 +1,10 @@
-import {
-  acceptance,
-  exists,
-  query,
-  queryAll,
-} from "discourse/tests/helpers/qunit-helpers";
-import { click, visit } from "@ember/test-helpers";
-import { clearPopupMenuOptionsCallback } from "discourse/controllers/composer";
-import I18n from "I18n";
+import { acceptance, exists } from "discourse/tests/helpers/qunit-helpers";
+import { click, currentURL, fillIn, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 
-acceptance("Data Explorer Plugin | Run Query", function (needs) {
+acceptance("Data Explorer Plugin | Param Input", function (needs) {
   needs.user();
   needs.settings({ data_explorer_enabled: true });
-  needs.hooks.beforeEach(() => {
-    clearPopupMenuOptionsCallback();
-  });
 
   needs.pretender((server, helper) => {
     server.get("/admin/plugins/explorer/groups.json", () => {
@@ -116,6 +106,61 @@ acceptance("Data Explorer Plugin | Run Query", function (needs) {
             hidden: false,
             user_id: -1,
           },
+          {
+            id: -7,
+            sql: "-- [params]\n-- user_id :user\n\nSELECT :user_id\n\n",
+            name: "Invalid Query",
+            description: "",
+            param_info: [
+              {
+                identifier: "user",
+                type: "user_id",
+                default: null,
+                nullable: false,
+              },
+            ],
+            created_at: "2022-01-14T16:40:05.458Z",
+            username: "bianca",
+            group_ids: [],
+            last_run_at: "2022-01-14T16:47:34.244Z",
+            hidden: false,
+            user_id: 1,
+          },
+        ],
+      });
+    });
+
+    server.put("/admin/plugins/explorer/queries/-6", () => {
+      return helper.response({
+        success: true,
+        errors: [],
+        duration: 27.5,
+        result_count: 2,
+        columns: ["user_id", "like_count"],
+        default_limit: 1000,
+        relations: {
+          user: [
+            {
+              id: -2,
+              username: "discobot",
+              name: null,
+              avatar_template: "/user_avatar/localhost/discobot/{size}/2_2.png",
+            },
+            {
+              id: 2,
+              username: "andrey1",
+              name: null,
+              avatar_template:
+                "/letter_avatar_proxy/v4/letter/a/c0e974/{size}.png",
+            },
+          ],
+        },
+        colrender: {
+          0: "user",
+        },
+        rows: [
+          [-2, 2],
+          [2, 2],
         ],
       });
     });
@@ -155,39 +200,48 @@ acceptance("Data Explorer Plugin | Run Query", function (needs) {
         ],
       });
     });
+
+    server.post("/admin/plugins/explorer/queries/-7/run", () => {
+      return helper.response({
+        success: true,
+        errors: [],
+        duration: 27.5,
+        params: { user_id: "null" },
+        columns: ["user_id"],
+        default_limit: 1000,
+        relations: {
+          user: [
+            {
+              id: 2,
+              username: "andrey1",
+              name: null,
+              avatar_template:
+                "/letter_avatar_proxy/v4/letter/a/c0e974/{size}.png",
+            },
+          ],
+        },
+        colrender: {
+          0: "user",
+        },
+        rows: [],
+      });
+    });
   });
 
-  test("it runs query and renders data and a chart", async function (assert) {
+  test("it puts params for the query into the url", async function (assert) {
     await visit("admin/plugins/explorer?id=-6");
-
-    assert.ok(
-      query("div.name h1").innerText.trim() === "Top 100 Likers",
-      "the query name was rendered"
-    );
-
-    assert.ok(exists("div.query-edit"), "the query code was rendered");
-
-    assert.ok(
-      query("form.query-run button span").innerText.trim() ===
-        I18n.t("explorer.run"),
-      "the run button was rendered"
-    );
-
+    const monthsAgoValue = "2";
+    await fillIn(".query-params input", monthsAgoValue);
     await click("form.query-run button");
 
-    assert.ok(
-      queryAll("div.query-results table tbody tr").length === 2,
-      "the table with query results was rendered"
-    );
+    const searchParams = new URLSearchParams(currentURL());
+    const monthsAgoParam = JSON.parse(searchParams.get("params")).months_ago;
+    assert.equal(monthsAgoParam, monthsAgoValue);
+  });
 
-    assert.ok(
-      query("div.result-info button:nth-child(3) span").innerText.trim() ===
-        I18n.t("explorer.show_graph"),
-      "the chart button was rendered"
-    );
-
-    await click("div.result-info button:nth-child(3)");
-
-    assert.ok(exists("canvas"), "the chart was rendered");
+  test("it loads the page if one of the parameter is null", async function (assert) {
+    await visit('admin/plugins/explorer?id=-7&params={"user":null}');
+    assert.ok(exists(".query-params .user-chooser"));
+    assert.ok(exists(".query-run .btn.btn-primary"));
   });
 });


### PR DESCRIPTION
After running a query with a non-default query param (inserting the new param into the url) we want to have the same params available after reloading the page. To do this we need to pass the updated params back up to the parent due to Octane's one direction data stream. I went over this with @pmusaraj and we both agreed this was extremely difficult to test due to needing to reload the page in a test, so we opted to move forward without one.

- Move param-input tests to a dedicated file