### PR TITLE
DEV: Update params for group reports

### DIFF
--- a/assets/javascripts/discourse/controllers/group-reports-show.js
+++ b/assets/javascripts/discourse/controllers/group-reports-show.js
@@ -68,6 +68,12 @@ export default Controller.extend({
         }
       );
     },
+
+    // This is necessary with glimmer's one way data stream to get the child's
+    // changes of 'params' to bubble up.
+    updateParams(identifier, value) {
+      this.set(`model.params.${identifier}`, value);
+    },
   }, // actions
 
   @discourseComputed("queryGroup.bookmark")


### PR DESCRIPTION
During the upgrade to Octane group reports did not have the necessary `updateParams` function added to have the param input changes bubble up to the parent. This PR adds the missing function as well as a small test to check that params can be inputted as expected (inserting a param would error previously).