### PR TITLE
FIX: Downloading query results

### DIFF
--- a/assets/javascripts/discourse/components/query-result.js
+++ b/assets/javascripts/discourse/components/query-result.js
@@ -231,7 +231,7 @@ export default class QueryResult extends Component {
       "action",
       getURL(
         this._download_url() +
-          this.get("query.id") +
+          this.args.query.id +
           "/run." +
           format +
           "?download=1"

--- a/assets/javascripts/discourse/components/query-results-wrapper.hbs
+++ b/assets/javascripts/discourse/components/query-results-wrapper.hbs
@@ -1,7 +1,7 @@
 {{#if @results}}
   <div class="query-results">
     {{#if @showResults}}
-      <QueryResult @query={{@selectedItem}} @content={{@results}} />
+      <QueryResult @query={{@query}} @content={{@results}} />
     {{else}}
       {{#each @results.errors as |err|}}
         <pre class="query-error"><code>{{~err}}</code></pre>


### PR DESCRIPTION
We were not passing the correct value from the `query-results-wrapper` to the `query-result` component causing downloads to fail.