### PR TITLE
FIX: Group reports downloads

### DIFF
--- a/assets/javascripts/discourse/components/query-result.js
+++ b/assets/javascripts/discourse/components/query-result.js
@@ -210,8 +210,8 @@ export default class QueryResult extends Component {
   }
 
   _download_url() {
-    return this.group
-      ? `/g/${this.group.name}/reports/`
+    return this.args.group
+      ? `/g/${this.args.group.name}/reports/`
       : "/admin/plugins/explorer/queries/";
   }
 

--- a/assets/javascripts/discourse/templates/group-reports-show.hbs
+++ b/assets/javascripts/discourse/templates/group-reports-show.hbs
@@ -31,7 +31,7 @@
   {{#if results}}
     <div class="query-results">
       {{#if showResults}}
-        {{query-result query=model content=results group=group}}
+        <QueryResult @query={{model}} @content={{results}} @group={{group}} />
       {{else}}
         {{#each results.errors as |err|}}
           <pre class="query-error"><code>{{~err}}</code></pre>


### PR DESCRIPTION
We were not passing the correct arguments through in the group reports template causing the download url to default to an admin route. This made downloads unavailable to non-admin users. Fixed by passing the correct values through.