### PR TITLE
FIX: Opening and closing of schema columns

### DIFF
--- a/assets/javascripts/discourse/components/explorer-schema/one-table.hbs
+++ b/assets/javascripts/discourse/components/explorer-schema/one-table.hbs
@@ -1,7 +1,6 @@
-{{! template-lint-disable no-invalid-interactive }}
-<li class="schema-table {{this.styles}}" {{on "click" this.toggleOpen}}>
+<li class="schema-table {{this.styles}}">
   {{! template-lint-enable no-invalid-interactive }}
-  <div class="schema-table-name">
+  <div class="schema-table-name" role="button" {{on "click" this.toggleOpen}}>
     {{#if this.open}}
       {{d-icon "caret-down"}}
     {{else}}


### PR DESCRIPTION
Per: https://meta.discourse.org/t/cant-select-a-column-name-as-releasing-the-mouse-click-will-close-the-current-table-dropdown/250715/3

Fixed column toggling where columns should open and close when clicking column name, and not when clicking the column body.