### PR TITLE
UX: Reduce the table height

### DIFF
--- a/assets/stylesheets/explorer.scss
+++ b/assets/stylesheets/explorer.scss
@@ -290,7 +290,7 @@ table.group-reports {
   section {
     width: 100%;
     overflow: auto;
-    height: 1000px;
+    max-height: 1000px;
   }
   table {
     width: 100%;


### PR DESCRIPTION
Prevent the table to have a fixed 1000px height with the horizontal scrollbar at the bottom of a mostly blank section when we have only a few results. This change doesn't interfere with the sticky header.

Before:
![before](https://user-images.githubusercontent.com/5654300/217013320-ec9136d6-d886-4cd8-87b4-36f53c207956.png)

After:
![after](https://user-images.githubusercontent.com/5654300/217013334-bcb3fcdd-05c1-4a0a-a7e9-a25468973511.png)
