### PR TITLE
FIX: Maintain editing state after saving query changes

### DIFF
--- a/assets/javascripts/discourse/controllers/admin-plugins-explorer.js
+++ b/assets/javascripts/discourse/controllers/admin-plugins-explorer.js
@@ -110,7 +110,6 @@ export default class PluginsExplorerController extends Controller {
       .then(() => {
         this.dirty = false;
         this.editingName = false;
-        this.editingQuery = false;
       })
       .catch((x) => {
         popupAjaxError(x);
@@ -327,8 +326,6 @@ export default class PluginsExplorerController extends Controller {
           this.selectedItem.set("group_ids", []);
         }
         this.dirty = false;
-        this.editingName = false;
-        this.editingQuery = false;
       })
       .catch(popupAjaxError)
       .finally(() => (this.loading = false));
@@ -383,10 +380,6 @@ export default class PluginsExplorerController extends Controller {
 
   @action
   run() {
-    if (this.dirty || this.runDisabled) {
-      return;
-    }
-
     this.setProperties({
       loading: true,
       showResults: false,

--- a/assets/javascripts/discourse/models/query.js
+++ b/assets/javascripts/discourse/models/query.js
@@ -56,4 +56,12 @@ export default class Query extends RestModel {
     }
     return props;
   }
+
+  createProperties() {
+    if (this.sql) {
+      // Importing
+      return this.updateProperties();
+    }
+    return this.getProperties("name");
+  }
 }

--- a/test/javascripts/acceptance/new-query-test.js
+++ b/test/javascripts/acceptance/new-query-test.js
@@ -1,0 +1,66 @@
+import { acceptance } from "discourse/tests/helpers/qunit-helpers";
+import { click, currentURL, fillIn, visit } from "@ember/test-helpers";
+import { clearPopupMenuOptionsCallback } from "discourse/controllers/composer";
+import { test } from "qunit";
+
+acceptance("Data Explorer Plugin | New Query", function (needs) {
+  needs.user();
+  needs.settings({ data_explorer_enabled: true });
+  needs.hooks.beforeEach(() => {
+    clearPopupMenuOptionsCallback();
+  });
+
+  needs.pretender((server, helper) => {
+    server.get("/admin/plugins/explorer/groups.json", () => {
+      return helper.response([]);
+    });
+
+    server.get("/admin/plugins/explorer/schema.json", () => {
+      return helper.response({});
+    });
+
+    server.get("/admin/plugins/explorer/queries", () => {
+      return helper.response({
+        queries: [],
+      });
+    });
+
+    server.post("/admin/plugins/explorer/queries", () => {
+      return helper.response({
+        query: {
+          id: -15,
+          sql: "-- [params]\n-- int :months_ago = 1\n\nWITH query_period AS\n(SELECT date_trunc('month', CURRENT_DATE) - INTERVAL ':months_ago months' AS period_start,\n                                                    date_trunc('month', CURRENT_DATE) - INTERVAL ':months_ago months' + INTERVAL '1 month' - INTERVAL '1 second' AS period_end)\nSELECT t.id AS topic_id,\n    t.category_id,\n    COUNT(p.id) AS reply_count\nFROM topics t\nJOIN posts p ON t.id = p.topic_id\nJOIN query_period qp ON p.created_at >= qp.period_start\nAND p.created_at <= qp.period_end\nWHERE t.archetype = 'regular'\nAND t.user_id > 0\nGROUP BY t.id\nORDER BY COUNT(p.id) DESC, t.score DESC\nLIMIT 100\n",
+          name: "foo",
+          description:
+            "based on the number of replies, it accepts a ‘months_ago’ parameter, defaults to 1 to give results for the last calendar month.",
+          param_info: [
+            {
+              identifier: "months_ago",
+              type: "int",
+              default: "1",
+              nullable: false,
+            },
+          ],
+          created_at: "2021-02-05T16:42:45.572Z",
+          username: "system",
+          group_ids: [],
+          last_run_at: "2021-02-08T15:37:49.188Z",
+          hidden: false,
+          user_id: -1,
+        },
+      });
+    });
+  });
+
+  test("creates a new query", async function (assert) {
+    await visit("admin/plugins/explorer");
+
+    // select new query button
+    await click(".query-list button");
+    await fillIn(".query-create input", "foo");
+    // select create new query button
+    await click(".query-create button");
+
+    assert.equal(currentURL(), "/admin/plugins/explorer?id=-15");
+  });
+});


### PR DESCRIPTION
In the widget version of the data-explorer we would maintain the `editing` state after saving query changes. This was lost in upgrade to glimmer. 

# Current State
https://user-images.githubusercontent.com/50783505/217622464-79adaab6-84ed-4b64-93ae-c889aa8fb1bd.mp4

# Updated State
https://user-images.githubusercontent.com/50783505/217623475-1998fab6-0b70-42d2-923d-574efb9d5601.mov

# Other Changes
- `createProperties` was added back to the `query` model as it is being utilized in the creation of a new data explorer query. This was accidentally removed and was causing errors when trying to create a new query.
- Add new-query test