### PR TITLE
DEV: Fix broken plugin specs because of bookmarkable changes

### DIFF
--- a/spec/lib/data_explorer_query_group_bookmarkable_spec.rb
+++ b/spec/lib/data_explorer_query_group_bookmarkable_spec.rb
@@ -34,7 +34,7 @@ describe DataExplorerQueryGroupBookmarkable do
     register_test_bookmarkable(DataExplorerQueryGroupBookmarkable)
   end
 
-  after { DiscoursePluginRegistry.reset! }
+  after { DiscoursePluginRegistry.reset_register!(:bookmarkables) }
 
   # Groups 0 and 1 have access to the Query 1.
   let!(:query_group1) { Fabricate(:query_group, query: query1, group: group0) }


### PR DESCRIPTION
Followup to 360d0dde650704a0f01fd6d8b525e933b1d7fcf2,
this causes other plugin tests to fail because
`DiscoursePluginRegistry.reset!` is
a shotgun. We can use the more surgical version
`DiscoursePluginRegistry.reset_register!(:bookmarkables)`
instead.
