### PR TITLE
FIX: Special attributes not working

### DIFF
--- a/assets/javascripts/discourse/components/query-row-content.js
+++ b/assets/javascripts/discourse/components/query-row-content.js
@@ -1,31 +1,14 @@
 import Component from "@glimmer/component";
-import { categoryLinkHTML } from "discourse/helpers/category-link";
-import { autoUpdatingRelativeAge } from "discourse/lib/formatter";
-import { convertIconClass, iconHTML } from "discourse-common/lib/icon-library";
 import getURL from "discourse-common/lib/get-url";
 import { capitalize } from "@ember/string";
-import { htmlSafe } from "@ember/template";
-import { get } from "@ember/object";
-import { isEmpty } from "@ember/utils";
 import { escapeExpression } from "discourse/lib/utilities";
 import { cached } from "@glimmer/tracking";
 import TextViewComponent from "./result-types/text";
 
 export default class QueryRowContent extends Component {
-  constructor() {
-    super(...arguments);
-
-    this.helpers = {
-      "icon-or-image": icon_or_image_replacement,
-      "category-link": category_badge_replacement,
-      reltime: bound_date_replacement,
-    };
-  }
-
   @cached
   get results() {
     return this.args.columnComponents.map((t, idx) => {
-      const params = {};
       const value = this.args.row[idx],
         id = parseInt(value, 10);
 
@@ -58,48 +41,16 @@ export default class QueryRowContent extends Component {
         ctx["target"] = name;
       }
 
-      if (t.name === "category" || t.name === "badge" || t.name === "reltime") {
-        // only replace helpers if needed
-        params.helpers = this.helpers;
-      }
-
       try {
         return {
           component: t.component || TextViewComponent,
           ctx,
-          params,
         };
       } catch (e) {
         return "error";
       }
     });
   }
-}
-
-function icon_or_image_replacement(str, ctx) {
-  str = get(ctx.contexts[0], str);
-  if (isEmpty(str)) {
-    return "";
-  }
-
-  if (str.indexOf("fa-") > -1) {
-    const icon = iconHTML(convertIconClass(str));
-    return htmlSafe(icon);
-  } else {
-    return htmlSafe("<img src='" + str + "'>");
-  }
-}
-
-function category_badge_replacement(str, ctx) {
-  const category = get(ctx.contexts[0], str);
-  return categoryLinkHTML(category, {
-    allowUncategorized: true,
-  });
-}
-
-function bound_date_replacement(str, ctx) {
-  const value = get(ctx.contexts[0], str);
-  return htmlSafe(autoUpdatingRelativeAge(new Date(value), { title: true }));
 }
 
 function guessUrl(t) {

--- a/assets/javascripts/discourse/components/result-types/badge.hbs
+++ b/assets/javascripts/discourse/components/result-types/badge.hbs
@@ -4,6 +4,6 @@
   title={{@ctx.badge.display_name}}
   data-badge-name={{@ctx.badge.name}}
 >
-  {{icon-or-image @ctx.badge.icon}}
+  {{this.iconOrImageReplacement}}
   <span class="badge-display-name">{{@ctx.badge.display_name}}</span>
 </a>

--- a/assets/javascripts/discourse/components/result-types/badge.js
+++ b/assets/javascripts/discourse/components/result-types/badge.js
@@ -1,0 +1,19 @@
+import Component from "@glimmer/component";
+import { isEmpty } from "@ember/utils";
+import { htmlSafe } from "@ember/template";
+import { convertIconClass, iconHTML } from "discourse-common/lib/icon-library";
+
+export default class Badge extends Component {
+  get iconOrImageReplacement() {
+    if (isEmpty(this.args.ctx.badge.icon)) {
+      return "";
+    }
+
+    if (this.args.ctx.badge.icon.indexOf("fa-") > -1) {
+      const icon = iconHTML(convertIconClass(this.args.ctx.badge.icon));
+      return htmlSafe(icon);
+    } else {
+      return htmlSafe("<img src='" + this.args.ctx.badge.icon + "'>");
+    }
+  }
+}

--- a/assets/javascripts/discourse/components/result-types/category.hbs
+++ b/assets/javascripts/discourse/components/result-types/category.hbs
@@ -1,5 +1,5 @@
 {{#if @ctx.category}}
-  {{category-link @ctx.category}}
+  {{this.categoryBadgeReplacement}}
 {{else}}
   <a href="{{@ctx.baseuri}}/t/{{@ctx.id}}">{{@ctx.id}}</a>
 {{/if}}

--- a/assets/javascripts/discourse/components/result-types/category.js
+++ b/assets/javascripts/discourse/components/result-types/category.js
@@ -1,0 +1,10 @@
+import Component from "@glimmer/component";
+import { categoryLinkHTML } from "discourse/helpers/category-link";
+
+export default class Category extends Component {
+  get categoryBadgeReplacement() {
+    return categoryLinkHTML(this.args.ctx.category, {
+      allowUncategorized: true,
+    });
+  }
+}

--- a/assets/javascripts/discourse/components/result-types/html.hbs
+++ b/assets/javascripts/discourse/components/result-types/html.hbs
@@ -1,1 +1,1 @@
-{{html-safe @textValue}}
+{{html-safe @ctx.value}}

--- a/assets/javascripts/discourse/components/result-types/reltime.hbs
+++ b/assets/javascripts/discourse/components/result-types/reltime.hbs
@@ -1,1 +1,1 @@
-{{reltime @textValue}}
+{{this.boundDateReplacement}}

--- a/assets/javascripts/discourse/components/result-types/reltime.js
+++ b/assets/javascripts/discourse/components/result-types/reltime.js
@@ -1,0 +1,11 @@
+import Component from "@glimmer/component";
+import { autoUpdatingRelativeAge } from "discourse/lib/formatter";
+import { htmlSafe } from "@ember/template";
+
+export default class Reltime extends Component {
+  get boundDateReplacement() {
+    return htmlSafe(
+      autoUpdatingRelativeAge(new Date(this.args.ctx.value), { title: true })
+    );
+  }
+}

--- a/assets/javascripts/discourse/controllers/admin-plugins-explorer.js
+++ b/assets/javascripts/discourse/controllers/admin-plugins-explorer.js
@@ -278,11 +278,6 @@ export default class PluginsExplorerController extends Controller {
   }
 
   @action
-  saveDefaults() {
-    this.selectedItem.saveDefaults();
-  }
-
-  @action
   updateSortProperty(property) {
     if (this.sortByProperty === property) {
       this.sortDescending = !this.sortDescending;


### PR DESCRIPTION
# Context
Data explorer gives you the ability to use special attributes such as 👇 

> SELECT TIMESTAMP 'yesterday' as reltime$time

# Problem
During the upgrade to ember octane these were neglected and did not work. This PR updates them to working condition.

# Additional
- Drop unused action of `saveDefaults`