### PR TITLE
FIX: Reset results on query redirect

### DIFF
--- a/assets/javascripts/discourse/routes/group-reports-show.js
+++ b/assets/javascripts/discourse/routes/group-reports-show.js
@@ -20,6 +20,8 @@ export default class GroupReportsShowRoute extends DiscourseRoute {
           model: Object.assign({ params: queryParams }, query),
           group,
           queryGroup,
+          results: null,
+          showResults: false,
         };
       })
       .catch(() => {


### PR DESCRIPTION
# Problem

When switching group reports it was possible to have the `results` from a previous run (of a query) pass over to the rendering of a different query.

# Fix

Set the controllers `results` to `null` when first rendering the query

https://user-images.githubusercontent.com/50783505/228050384-5231f004-1dc2-4867-8d57-9db7706bb65f.mov

