### PR TITLE
DEV: Add configurable rate limit for Data Explorer API query runs

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -38,6 +38,14 @@ after_initialize do
   require_relative "lib/discourse_data_explorer/queries"
   require_relative "lib/discourse_data_explorer/query_group_bookmarkable"
 
+  GlobalSetting.add_default(:max_data_explorer_api_reqs_per_10_seconds, 2)
+
+  # Available options:
+  #   - warn
+  #   - warn+block
+  #   - block
+  GlobalSetting.add_default(:max_data_explorer_api_req_mode, "warn")
+
   add_to_class(:guardian, :user_is_a_member_of_group?) do |group|
     return false if !current_user
     return true if current_user.admin?


### PR DESCRIPTION
### Background

Data Explorer can run arbitrary SQL queries which can be costly for us if over-used. Because of that we want to add the ability to rate limit the query run endpoint, in particular when requested programmatically using API.

### What is this change?

This introduces a rate limit to the `QueryController#run` endpoint. It heavily leans on the existing `RateLimiter` implementation, and the ability of `ApplicationController` to [turn rate limit exceptions into nicely formatted JSON responses](https://github.com/discourse/discourse/blob/main/app/controllers/application_controller.rb#L180-L199).

The rate limit (per 10 seconds) can be configured through the global setting `max_data_explorer_api_reqs_per_10_seconds`, and defaults to 2.

Handling can be configured through `max_data_explorer_api_req_mode`, and can be set to warn, block, or both warn and block. We will default to `warn` for now and monitor the logs for a while.

### What does a rate limit response look like to end users?

Here's the response body generated from Postman locally:

```json
{
    "errors": [
        "You’ve performed this action too many times. Please wait 5 seconds before trying again."
    ],
    "error_type": "rate_limit",
    "extras": {
        "wait_seconds": 5,
        "time_left": "5 seconds"
    }
}
```

There's also an extra header in the response:

```
Retry-After: 5
```

### Manual verification

- [x] You can run queries in the UI to your heart's content.
- [x] API requests to the run endpoint are rate limited.