### PR TITLE
FIX: Reduce issues when debouncing schema search

### DIFF
--- a/assets/javascripts/discourse/components/explorer-schema.hbs
+++ b/assets/javascripts/discourse/components/explorer-schema.hbs
@@ -7,7 +7,10 @@
 {{else}}
   <div class="schema">
     <div class="schema-search inline-form full-width">
-      <Input {{on "input" (action "filterChanged" value="target.value")}} />
+      <input
+        type="text"
+        {{on "input" (action "filterChanged" value="target.value")}}
+      />
       <DButton
         @action={{this.collapseSchema}}
         @icon="chevron-right"

--- a/assets/javascripts/discourse/components/explorer-schema.hbs
+++ b/assets/javascripts/discourse/components/explorer-schema.hbs
@@ -7,11 +7,7 @@
 {{else}}
   <div class="schema">
     <div class="schema-search inline-form full-width">
-      <TextField
-        @value={{this.filterInput}}
-        @onChange={{this.filterChanged}}
-        @placeholderKey="explorer.schema.filter"
-      />
+      <Input {{on "input" (action "filterChanged" value="target.value")}} />
       <DButton
         @action={{this.collapseSchema}}
         @icon="chevron-right"

--- a/assets/javascripts/discourse/components/explorer-schema.hbs
+++ b/assets/javascripts/discourse/components/explorer-schema.hbs
@@ -4,13 +4,11 @@
     @icon="chevron-left"
     @class="no-text unhide"
   />
-{{/if}}
-
-<div class="schema">
-  <div class={{if this.hideSchema "hidden"}}>
+{{else}}
+  <div class="schema">
     <div class="schema-search inline-form full-width">
       <TextField
-        @value={{this.filter}}
+        @value={{this.filterInput}}
         @onChange={{this.filterChanged}}
         @placeholderKey="explorer.schema.filter"
       />
@@ -21,14 +19,14 @@
       />
     </div>
 
-    <ConditionalLoadingSpinner @condition={{this.loading}}>
-      <div class="schema-container">
+    <div class="schema-container">
+      <ConditionalLoadingSpinner @condition={{this.loading}}>
         <ul>
           {{#each this.filteredTables as |table|}}
             <ExplorerSchema::OneTable @table={{table}} />
           {{/each}}
         </ul>
-      </div>
-    </ConditionalLoadingSpinner>
+      </ConditionalLoadingSpinner>
+    </div>
   </div>
-</div>
+{{/if}}

--- a/assets/javascripts/discourse/components/explorer-schema.js
+++ b/assets/javascripts/discourse/components/explorer-schema.js
@@ -5,6 +5,8 @@ import { action } from "@ember/object";
 import { tracked } from "@glimmer/tracking";
 
 export default class ExplorerSchema extends Component {
+  filterInput = "";
+
   @tracked filter;
   @tracked loading;
   @tracked hideSchema = this.args.hideSchema;

--- a/assets/javascripts/discourse/components/explorer-schema.js
+++ b/assets/javascripts/discourse/components/explorer-schema.js
@@ -9,8 +9,6 @@ export default class ExplorerSchema extends Component {
   @tracked loading;
   @tracked hideSchema = this.args.hideSchema;
 
-  filterInput = "";
-
   get transformedSchema() {
     const schema = this.args.schema;
     for (const key in schema) {

--- a/assets/javascripts/discourse/components/explorer-schema.js
+++ b/assets/javascripts/discourse/components/explorer-schema.js
@@ -5,11 +5,11 @@ import { action } from "@ember/object";
 import { tracked } from "@glimmer/tracking";
 
 export default class ExplorerSchema extends Component {
-  filterInput = "";
-
   @tracked filter;
   @tracked loading;
   @tracked hideSchema = this.args.hideSchema;
+
+  filterInput = "";
 
   get transformedSchema() {
     const schema = this.args.schema;

--- a/assets/stylesheets/explorer.scss
+++ b/assets/stylesheets/explorer.scss
@@ -46,9 +46,6 @@ table.group-reports {
         margin-left: -53px;
         z-index: 1;
       }
-      .schema {
-        display: none;
-      }
     }
   }
 
@@ -78,10 +75,16 @@ table.group-reports {
       overflow-x: hidden;
       color: var(--primary-high);
       font-size: var(--font-down-1);
+      position: relative;
 
       .schema-search {
-        margin: 0.5em;
+        padding: 0.5em;
+        position: sticky;
+        background-color: var(--secondary);
+        top: 0px;
+        z-index: 1;
       }
+
       .schema-table-name {
         font-weight: bold;
         border-bottom: 1px solid var(--primary-low);


### PR DESCRIPTION
Previously the debounced value was both setting the filter value and updating the input's text value. This causes visible UI issues, because the debounce updating the input's text value would sometimes reset it, especially if/when typing quickly.

This separates the `filter` onChange event from the input value.

This PR also uses sticky positioning for the search form, so that it stays visible even when scrolling the list of schema tables.

![screencast 2023-04-17 18-42-18](https://user-images.githubusercontent.com/368961/232626095-e8683b06-f59b-4f76-898e-3188dbeca695.gif)

