### PR TITLE
UX: fix parameters inputs spacing

### DIFF
--- a/assets/stylesheets/explorer.scss
+++ b/assets/stylesheets/explorer.scss
@@ -457,4 +457,3 @@ table.group-reports {
     color: var(--tertiary);
   }
 }
-

--- a/assets/stylesheets/explorer.scss
+++ b/assets/stylesheets/explorer.scss
@@ -241,6 +241,9 @@ table.group-reports {
 
 .query-params {
   border: 1px solid var(--header_primary-medium);
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
   .param > input,
   .param > .select-kit {
     margin: 9px;
@@ -252,9 +255,9 @@ table.group-reports {
     background-color: var(--danger-low);
   }
   .param {
-    width: 300px;
-    display: inline-block;
-    overflow-x: visible;
+    display: flex;
+    align-items: center;
+    flex: 0;
     .ac-wrap {
       display: inline-block;
       input {
@@ -263,12 +266,12 @@ table.group-reports {
     }
     input,
     .select-kit {
-      width: 190px;
+      width: auto;
+      max-width: 250px;
     }
   }
   .param-name {
-    display: inline-block;
-    width: 70px;
+    margin-right: 1em;
   }
 }
 
@@ -454,3 +457,4 @@ table.group-reports {
     color: var(--tertiary);
   }
 }
+


### PR DESCRIPTION
Fix the spacing between parameters inputs.

Before:
![image](https://github.com/discourse/discourse-data-explorer/assets/5654300/c1a684a5-c038-45f2-a3f4-8ccb0c78ad8d)

After (I forgot to add a select kit on the first screenshot, but that doesn't really matter here):
![image](https://github.com/discourse/discourse-data-explorer/assets/5654300/32586702-f5cf-4968-a591-705e40f349ed)

I removed some arbitrary widths that didn't seem necessary and also center-aligned content.
Elements will go on multiple lines if the container is too narrow.
If a select-kit is populated with a long string, it will overflow on mobile, but I don't think it's an issue since data explorer isn't exactly made for mobile (it already has a select-kit overflow I didn't bother fixing).

Besides this, the fields will be properly displayed on mobile in normal use anyway.