### PR TITLE
FIX: Increase z-index of th element

### DIFF
--- a/assets/stylesheets/explorer.scss
+++ b/assets/stylesheets/explorer.scss
@@ -311,6 +311,7 @@ table.group-reports {
       top: 0;
       color: var(--primary);
       background: var(--primary-low);
+      z-index: z("base");
     }
   }
 }


### PR DESCRIPTION
This PR prevents items in the category column from appearing on top of the table header.

This is due to relative positioning of the badge-wrapper elements in the category column when visible.

This is a more simple fix than changing that element.

# Before
<img width="600" alt="image" src="https://github.com/discourse/discourse-data-explorer/assets/30537603/522b9589-7014-42e6-b1b4-32c810bf820e">

# After
<img width="600" alt="image" src="https://github.com/discourse/discourse-data-explorer/assets/30537603/26f4617a-4d70-4496-986e-cc350148ab7a">
