### PR TITLE
FIX: update report url to work with subfolder installs

### DIFF
--- a/lib/report_generator.rb
+++ b/lib/report_generator.rb
@@ -66,7 +66,7 @@ module ::DiscourseDataExplorer
         pm["target_usernames"] = Array(username)
         pm["raw"] = "Hi #{username}, your data explorer report is ready.\n\n" +
           "Query Name:\n#{query.name}\n\nHere are the results:\n#{table}\n\n" +
-          "<a href='/admin/plugins/explorer?id=#{query.id}'>View query in Data Explorer</a>\n\n" +
+          "<a href='#{Discourse.base_url}/admin/plugins/explorer?id=#{query.id}'>View query in Data Explorer</a>\n\n" +
           "Report created at #{Time.zone.now.strftime("%Y-%m-%d at %H:%M:%S")} (#{Time.zone.name})"
         pms << pm
       end

--- a/spec/report_generator_spec.rb
+++ b/spec/report_generator_spec.rb
@@ -48,7 +48,7 @@ describe DiscourseDataExplorer::ReportGenerator do
             "raw" =>
               "Hi #{user.username}, your data explorer report is ready.\n\n" +
                 "Query Name:\n#{query.name}\n\nHere are the results:\nle table\n\n" +
-                "<a href='/admin/plugins/explorer?id=#{query.id}'>View query in Data Explorer</a>\n\n" +
+                "<a href='#{Discourse.base_url}/admin/plugins/explorer?id=#{query.id}'>View query in Data Explorer</a>\n\n" +
                 "Report created at #{Time.zone.now.strftime("%Y-%m-%d at %H:%M:%S")} (#{Time.zone.name})",
           },
         ],


### PR DESCRIPTION
This change includes the Discourse base url to allow for subfolder installs, it will also fix another potential issue where reports are sent via email (since we use the `email_group_user` component) that would require the `base_url` to know which domain to point to.