### PR TITLE
FEATURE: Add JSON result type component

### DIFF
--- a/assets/javascripts/discourse/components/query-result.js
+++ b/assets/javascripts/discourse/components/query-result.js
@@ -17,6 +17,7 @@ import UrlViewComponent from "./result-types/url";
 import UserViewComponent from "./result-types/user";
 import GroupViewComponent from "./result-types/group";
 import HtmlViewComponent from "./result-types/html";
+import JsonViewComponent from "./result-types/json";
 import CategoryViewComponent from "./result-types/category";
 
 const VIEW_COMPONENTS = {
@@ -29,6 +30,7 @@ const VIEW_COMPONENTS = {
   user: UserViewComponent,
   group: GroupViewComponent,
   html: HtmlViewComponent,
+  json: JsonViewComponent,
   category: CategoryViewComponent,
 };
 

--- a/assets/javascripts/discourse/components/result-types/json.hbs
+++ b/assets/javascripts/discourse/components/result-types/json.hbs
@@ -1,0 +1,9 @@
+<div class="result-json">
+  <div class="result-json-value">{{@ctx.value}}</div>
+  <DButton
+    @class="result-json-button"
+    @action={{action "viewJson"}}
+    @icon="ellipsis-h"
+    @title="explorer.view_json"
+  />
+</div>

--- a/assets/javascripts/discourse/components/result-types/json.hbs
+++ b/assets/javascripts/discourse/components/result-types/json.hbs
@@ -1,7 +1,7 @@
 <div class="result-json">
   <div class="result-json-value">{{@ctx.value}}</div>
   <DButton
-    @class="result-json-button"
+    class="result-json-button"
     @action={{action "viewJson"}}
     @icon="ellipsis-h"
     @title="explorer.view_json"

--- a/assets/javascripts/discourse/components/result-types/json.js
+++ b/assets/javascripts/discourse/components/result-types/json.js
@@ -1,0 +1,31 @@
+import Component from "@glimmer/component";
+import FullscreenCodeModal from "discourse/components/modal/fullscreen-code";
+import { inject as service } from "@ember/service";
+import { action } from "@ember/object";
+import { cached } from "@glimmer/tracking";
+
+export default class Json extends Component {
+  @service dialog;
+  @service modal;
+
+  @cached
+  get parsedJson() {
+    try {
+      return JSON.parse(this.args.ctx.value);
+    } catch {
+      return null;
+    }
+  }
+
+  @action
+  viewJson() {
+    this.modal.show(FullscreenCodeModal, {
+      model: {
+        code: this.parsedJson
+          ? JSON.stringify(this.parsedJson, null, 2)
+          : this.args.ctx.value,
+        codeClasses: "",
+      },
+    });
+  }
+}

--- a/assets/stylesheets/explorer.scss
+++ b/assets/stylesheets/explorer.scss
@@ -416,6 +416,18 @@ table.group-reports {
   display: block;
   color: inherit !important;
 }
+.result-json {
+  display: flex;
+}
+
+.result-json-value {
+  flex: 1;
+  margin-right: 0.5em;
+  max-width: 250px;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+}
 
 .explorer-pad-bottom {
   margin-bottom: 200px;

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -56,6 +56,7 @@ en:
           no: "No"
           null_: "Null"
       export: "Export"
+      view_json: "View JSON"
       save: "Save Changes"
       saverun: "Save Changes and Run"
       run: "Run"

--- a/lib/discourse_data_explorer/data_explorer.rb
+++ b/lib/discourse_data_explorer/data_explorer.rb
@@ -5,6 +5,10 @@ module ::DiscourseDataExplorer
   end
 
   module DataExplorer
+    # Used for ftype calls, see https://www.rubydoc.info/gems/pg/0.17.1/PG%2FResult:ftype
+    # and /usr/include/postgresql/server/catalog/pg_type_d.h
+    PG_TYPE_OID_JSON = 114
+
     # Run a data explorer query on the currently connected database.
     #
     # @param [Query] query the Query object to run
@@ -131,6 +135,9 @@ module ::DiscourseDataExplorer
         html: {
           ignore: true,
         },
+        json: {
+          ignore: true,
+        },
       }
     end
 
@@ -145,7 +152,6 @@ module ::DiscourseDataExplorer
       needed_classes = {}
       ret = {}
       col_map = {}
-
       pg_result.fields.each_with_index do |col, idx|
         rgx = column_regexes.find { |r| r.match col }
         if rgx
@@ -158,6 +164,8 @@ module ::DiscourseDataExplorer
           needed_classes[cls] << idx
         elsif col =~ /^\w+_url$/
           col_map[idx] = "url"
+        elsif col =~ /^\w+_payload$/ || col == "payload" || pg_result.ftype(idx) == PG_TYPE_OID_JSON
+          col_map[idx] = "json"
         end
       end
 

--- a/spec/system/reports_spec.rb
+++ b/spec/system/reports_spec.rb
@@ -42,4 +42,18 @@ RSpec.describe "Reports", type: :system, js: true do
     find(".query-run .btn-primary").click
     expect(page).to have_css(".query-results .result-header")
   end
+
+  it "allows user to run a report with a JSON column and open a fullscreen code viewer" do
+    Fabricate(:reviewable_queued_post)
+    sql = <<~SQL
+      SELECT id, payload FROM reviewables LIMIT 10
+    SQL
+    json_query = DiscourseDataExplorer::Query.create!(name: "some query", sql: sql)
+    sign_in(user)
+    visit("/g/group/reports/#{json_query.id}")
+    find(".query-run .btn-primary").click
+    expect(page).to have_css(".query-results .result-json")
+    first(".query-results .result-json .btn.result-json-button").click
+    expect(page).to have_css(".fullscreen-code-modal")
+  end
 end


### PR DESCRIPTION
If a column is `payload` or contains `_payload` it will be assumed
it has JSON data in it, then we will show the truncated JSON in the
result column with a button to show the full-screen formatted
JSON using our full-screen code viewer.

![image](https://github.com/discourse/discourse-data-explorer/assets/920448/e6229b9c-0080-4fee-88ea-3aab3220b8aa)
![image](https://github.com/discourse/discourse-data-explorer/assets/920448/7f77a1b7-d8d0-4ddb-9d29-0237c4635264)
