### PR TITLE
DEV: Update `visit` paths in tests

### DIFF
--- a/test/javascripts/acceptance/list-queries-test.js
+++ b/test/javascripts/acceptance/list-queries-test.js
@@ -143,7 +143,7 @@ acceptance("Data Explorer Plugin | List Queries", function (needs) {
   });
 
   test("it renders the page with the list of queries", async function (assert) {
-    await visit("admin/plugins/explorer");
+    await visit("/admin/plugins/explorer");
 
     assert.ok(
       query("div.query-list input.ember-text-field").placeholder ===

--- a/test/javascripts/acceptance/new-query-test.js
+++ b/test/javascripts/acceptance/new-query-test.js
@@ -53,7 +53,7 @@ acceptance("Data Explorer Plugin | New Query", function (needs) {
   });
 
   test("creates a new query", async function (assert) {
-    await visit("admin/plugins/explorer");
+    await visit("/admin/plugins/explorer");
 
     // select new query button
     await click(".query-list button");

--- a/test/javascripts/acceptance/param-input-test.js
+++ b/test/javascripts/acceptance/param-input-test.js
@@ -299,7 +299,7 @@ acceptance("Data Explorer Plugin | Param Input", function (needs) {
   });
 
   test("it puts params for the query into the url", async function (assert) {
-    await visit("admin/plugins/explorer?id=-6");
+    await visit("/admin/plugins/explorer?id=-6");
     const monthsAgoValue = "2";
     await fillIn(".query-params input", monthsAgoValue);
     await click("form.query-run button");

--- a/test/javascripts/acceptance/run-query-test.js
+++ b/test/javascripts/acceptance/run-query-test.js
@@ -186,7 +186,7 @@ acceptance("Data Explorer Plugin | Run Query", function (needs) {
   });
 
   test("it runs query and renders data and a chart", async function (assert) {
-    await visit("admin/plugins/explorer?id=-6");
+    await visit("/admin/plugins/explorer?id=-6");
 
     assert.ok(
       query("div.name h1").innerText.trim() === "Top 100 Likers",
@@ -220,7 +220,7 @@ acceptance("Data Explorer Plugin | Run Query", function (needs) {
   });
 
   test("it runs query and renders 0, false, and NULL values correctly", async function (assert) {
-    await visit("admin/plugins/explorer?id=2");
+    await visit("/admin/plugins/explorer?id=2");
 
     assert.ok(
       query("div.name h1").innerText.trim() === "What about 0?",


### PR DESCRIPTION
Omitting `/` prefix was incorrect and could break in the future (see: https://github.com/discourse/discourse/pull/24445)