### PR TITLE
UX: Warn in /logs when PM is not sent

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -116,7 +116,13 @@ after_initialize do
             DiscourseDataExplorer::ReportGenerator.new(automation.last_updated_by_id)
           report_pms = data_explorer_report.generate(query_id, query_params, recipients)
 
-          report_pms.each { |pm| utils.send_pm(pm, automation_id: automation.id) }
+          report_pms.each do |pm|
+            begin
+              utils.send_pm(pm, automation_id: automation.id)
+            rescue ActiveRecord::RecordNotSaved => e
+              Rails.logger.warn "#{DiscourseDataExplorer::PLUGIN_NAME} - couldn't send PM for automation #{automation.id}: #{e.message}"
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
Currently when a PM is not sent due to the query exceeding the PM char limit, there is no indication to the admin.

This simply adds it to logs for now, as we figure out a better way to surface such configuration problems through `ProblemChecker`, or another means.

https://github.com/discourse/discourse-automation/pull/235