### PR TITLE
FEATURE: Allow topic URL without post number for post_id param

### DIFF
--- a/assets/javascripts/discourse/components/param-input.js
+++ b/assets/javascripts/discourse/components/param-input.js
@@ -124,7 +124,13 @@ export default class ParamInput extends Component {
       case "int_list":
         return value.split(",").every((i) => /^(-?\d+|null)$/.test(i.trim()));
       case "post_id":
-        return isPositiveInt || /\d+\/\d+(\?u=.*)?$/.test(value);
+        return (
+          isPositiveInt ||
+          /\d+\/\d+(\?u=.*)?$/.test(value) ||
+          /\/t\/[^/]+\/(\d+)(\?u=.*)?/.test(value)
+        );
+      case "topic_id":
+        return isPositiveInt || /\/t\/[^/]+\/(\d+)/.test(value);
       case "category_id":
         if (isPositiveInt) {
           return !!this.site.categories.find((c) => c.id === intVal);

--- a/spec/lib/parameter_spec.rb
+++ b/spec/lib/parameter_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+RSpec.describe DiscourseDataExplorer::Parameter do
+  def param(identifier, type, default, nullable)
+    described_class.new(identifier, type, default, nullable)
+  end
+
+  describe ".cast_to_ruby" do
+    it "returns nil for nullable blank string" do
+      expect(param("param123", :string, nil, true).cast_to_ruby("")).to eq(nil)
+    end
+
+    it "raises error for not-nullable blank string" do
+      expect { param("param123", :string, nil, false).cast_to_ruby("") }.to raise_error(
+        ::DiscourseDataExplorer::ValidationError,
+      )
+    end
+
+    describe "post_id type" do
+      fab!(:post)
+
+      context "when the value provided is a post share URL" do
+        it "returns the found post id" do
+          expect(param("post_id", :post_id, nil, false).cast_to_ruby(post.url)).to eq(post.id)
+        end
+
+        it "returns the found post id when there is a share user param" do
+          expect(
+            param("post_id", :post_id, nil, false).cast_to_ruby(
+              "#{post.url}?u=#{post.user.username}",
+            ),
+          ).to eq(post.id)
+        end
+
+        it "returns the found post id when no post number is provided" do
+          expect(
+            param("post_id", :post_id, nil, false).cast_to_ruby("#{post.url(share_url: true)}"),
+          ).to eq(post.id)
+        end
+
+        it "raises an error if no such post exists" do
+          post.destroy
+          expect { param("post_id", :post_id, nil, false).cast_to_ruby(post.url) }.to raise_error(
+            ::DiscourseDataExplorer::ValidationError,
+          )
+        end
+      end
+
+      context "when the value provided is an integer" do
+        it "raises an error if no such post exists" do
+          expect { param("post_id", :post_id, nil, false).cast_to_ruby("-999") }.to raise_error(
+            ::DiscourseDataExplorer::ValidationError,
+          )
+        end
+
+        it "returns the post id if the post exists" do
+          expect(param("post_id", :post_id, nil, false).cast_to_ruby(post.id.to_s)).to eq(post.id)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This commit allows base topic URLs (e.g. https://meta.discourse.org/t/hide-text-in-text-select-popup-menu-feedback/287656)
to be used by the post_id parameter type. We just assume in this case
that the post_id for the param is 1.
