### PR TITLE
FEATURE: Add ability to skip sending the PM if there are no results

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -107,4 +107,6 @@ en:
               label: Data Explorer Query
             query_params:
               label: Data Explorer Query parameters
+            skip_empty:
+              label: Skip sending PM if there are no results
 

--- a/lib/report_generator.rb
+++ b/lib/report_generator.rb
@@ -2,7 +2,7 @@
 
 module ::DiscourseDataExplorer
   class ReportGenerator
-    def self.generate(query_id, query_params, recipients, opts)
+    def self.generate(query_id, query_params, recipients, opts = {})
       query = DiscourseDataExplorer::Query.find(query_id)
       return [] if !query || recipients.empty?
 

--- a/plugin.rb
+++ b/plugin.rb
@@ -89,6 +89,7 @@ after_initialize do
         field :recipients, component: :email_group_user, required: true
         field :query_id, component: :choices, required: true, extra: { content: queries }
         field :query_params, component: :"key-value", accepts_placeholders: true
+        field :skip_empty, component: :boolean
 
         version 1
         triggerables [:recurring]
@@ -97,6 +98,7 @@ after_initialize do
           recipients = Array(fields.dig("recipients", "value")).uniq
           query_id = fields.dig("query_id", "value")
           query_params = fields.dig("query_params", "value") || {}
+          skip_empty = fields.dig("skip_empty", "value") || false
 
           unless SiteSetting.data_explorer_enabled
             Rails.logger.warn "#{DiscourseDataExplorer::PLUGIN_NAME} - plugin must be enabled to run automation #{automation.id}"
@@ -109,7 +111,7 @@ after_initialize do
           end
 
           DiscourseDataExplorer::ReportGenerator
-            .generate(query_id, query_params, recipients)
+            .generate(query_id, query_params, recipients, { skip_empty: })
             .each do |pm|
               begin
                 utils.send_pm(pm, automation_id: automation.id, prefers_encrypt: false)

--- a/spec/automation/recurring_data_explorer_result_pm_spec.rb
+++ b/spec/automation/recurring_data_explorer_result_pm_spec.rb
@@ -90,7 +90,7 @@ describe "RecurringDataExplorerResultPm" do
 
       automation.update(last_updated_by_id: admin.id)
 
-      expect{ automation.trigger! }.to_not change { Post.count }
+      expect { automation.trigger! }.to_not change { Post.count }
     end
   end
 end

--- a/spec/automation/recurring_data_explorer_result_pm_spec.rb
+++ b/spec/automation/recurring_data_explorer_result_pm_spec.rb
@@ -84,5 +84,13 @@ describe "RecurringDataExplorerResultPm" do
         "Hi #{another_group.name}, your data explorer report is ready.\n\nQuery Name:\n#{query.name}",
       )
     end
+
+    it "does not send the PM if skip_empty" do
+      automation.upsert_field!("skip_empty", "boolean", { value: true })
+
+      automation.update(last_updated_by_id: admin.id)
+
+      expect{ automation.trigger! }.to_not change { Post.count }
+    end
   end
 end


### PR DESCRIPTION
There exists an automation script in data explorer which allows users to send a PM with the results of the explorer query. Sometimes, we don't want the PM to be sent if there are simply no rows yielded by the query.

<img width="431" alt="Screenshot 2024-04-18 at 9 14 40 PM" src="https://github.com/discourse/discourse-data-explorer/assets/1555215/2e205e7f-5dac-4837-9b54-312e74c8d836">

This PR adds an additional option "Skip sending PM if there are no results".

<img width="523" alt="Screenshot 2024-04-18 at 9 15 55 PM" src="https://github.com/discourse/discourse-data-explorer/assets/1555215/bd3e4dee-3bd9-4b0a-9e1b-c35dda46ec37">
