### PR TITLE
DEV: Rename `Jobs::DiscourseAutomationTracker` -> `Jobs::DiscourseAutomation::Tracker`

### DIFF
--- a/spec/automation/recurring_data_explorer_result_pm_spec.rb
+++ b/spec/automation/recurring_data_explorer_result_pm_spec.rb
@@ -47,7 +47,7 @@ describe "RecurringDataExplorerResultPm" do
   context "when using recurring trigger" do
     it "sends the pm at recurring date_date" do
       freeze_time 1.day.from_now do
-        expect { Jobs::DiscourseAutomationTracker.new.execute }.to change { Topic.count }.by(3)
+        expect { Jobs::DiscourseAutomation::Tracker.new.execute }.to change { Topic.count }.by(3)
 
         title = "Scheduled Report for #{query.name}"
         expect(Topic.last(3).pluck(:title)).to eq([title, title, title])


### PR DESCRIPTION
The class is renamed in https://github.com/discourse/discourse/pull/26860.