### PR TITLE
FIX: Use correct label for column header

### DIFF
--- a/assets/javascripts/discourse/templates/admin/plugins-explorer.hbs
+++ b/assets/javascripts/discourse/templates/admin/plugins-explorer.hbs
@@ -294,7 +294,7 @@
               >
                 <TableHeaderToggle
                   @field="name"
-                  @labelKey="explorer.query_user"
+                  @labelKey="explorer.query_name"
                   @order={{this.order}}
                   @asc={{not this.sortDescending}}
                   @automatic="true"


### PR DESCRIPTION
This PR changes the header for the first column of the queries table to have the correct label. Currently it says "Created by", but it should be "Query".

Before:

![image](https://github.com/discourse/discourse-data-explorer/assets/17474474/30dea56c-c544-4c69-9c36-55c69ec44522)

After:

![image](https://github.com/discourse/discourse-data-explorer/assets/17474474/f07b40d6-04c4-480d-909f-33814a3dcbb9)
