### PR TITLE
FEATURE: Add shortcut keys for save and execute for query editor

### DIFF
--- a/assets/javascripts/discourse/templates/admin/plugins-explorer.hbs
+++ b/assets/javascripts/discourse/templates/admin/plugins-explorer.hbs
@@ -128,6 +128,8 @@
                     @mode="sql"
                     @disabled={{this.selectedItem.destroyed}}
                     {{on "click" this.setDirty}}
+                    @save={{this.save}}
+                    @submit={{this.saveAndRun}}
                   />
                 </div>
 


### PR DESCRIPTION
This is a very simple change that adds two shortcuts to the query editor in Data Explorer: `ctrl+s` to save, and `ctrl+enter` to save and run the query.

Related meta topic: https://meta.discourse.org/t/wishlist-ctrl-enter-to-run-the-data-explorer-query-im-editing/280564