### PR TITLE
FIX: Wrong type in category_id param input

### DIFF
--- a/assets/javascripts/discourse/components/param-input.js
+++ b/assets/javascripts/discourse/components/param-input.js
@@ -164,6 +164,7 @@ export default class ParamInput extends Component {
   }
 
   dasherizeCategoryId(value) {
+    value = String(value || "");
     const isPositiveInt = /^\d+$/.test(value);
     if (!isPositiveInt && value !== dasherize(value)) {
       return dasherize(value);

--- a/spec/system/param_input_spec.rb
+++ b/spec/system/param_input_spec.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe "Param input", type: :system, js: true do
-  fab!(:category)
-  fab!(:group)
-
   ALL_PARAMS_SQL = <<~SQL
     -- [params]
     -- int          :int
@@ -39,8 +36,8 @@ RSpec.describe "Param input", type: :system, js: true do
     -- topic_id     :topic_id_with_default = /t/-/21
     -- int_list     :int_list_with_default = 1,2,3
     -- string_list  :string_list_with_default = a,b,c
-    -- category_id  :category_id_with_default = #{category.name}
-    -- group_id     :group_id_with_default = #{group.name}
+    -- category_id  :category_id_with_default = general
+    -- group_id     :group_id_with_default = staff
     -- user_list    :mul_users_with_default = system,discobot
     SELECT 1
   SQL

--- a/spec/system/param_input_spec.rb
+++ b/spec/system/param_input_spec.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 RSpec.describe "Param input", type: :system, js: true do
+  fab!(:category)
+  fab!(:group)
+
   ALL_PARAMS_SQL = <<~SQL
     -- [params]
     -- int          :int
@@ -36,8 +39,8 @@ RSpec.describe "Param input", type: :system, js: true do
     -- topic_id     :topic_id_with_default = /t/-/21
     -- int_list     :int_list_with_default = 1,2,3
     -- string_list  :string_list_with_default = a,b,c
-    -- category_id  :category_id_with_default = meta
-    -- group_id     :group_id_with_default = admins
+    -- category_id  :category_id_with_default = #{category.name}
+    -- group_id     :group_id_with_default = #{group.name}
     -- user_list    :mul_users_with_default = system,discobot
     SELECT 1
   SQL

--- a/spec/system/param_input_spec.rb
+++ b/spec/system/param_input_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+RSpec.describe "Param input", type: :system, js: true do
+  ALL_PARAMS_SQL = <<~SQL
+    -- [params]
+    -- int          :int
+    -- bigint       :bigint
+    -- boolean      :boolean
+    -- null boolean :boolean_three
+    -- string       :string
+    -- date         :date
+    -- time         :time
+    -- datetime     :datetime
+    -- double       :double
+    -- string       :inet
+    -- user_id      :user_id
+    -- post_id      :post_id
+    -- topic_id     :topic_id
+    -- int_list     :int_list
+    -- string_list  :string_list
+    -- category_id  :category_id
+    -- group_id     :group_id
+    -- user_list    :mul_users
+    -- int          :int_with_default = 3
+    -- bigint       :bigint_with_default = 12345678912345
+    -- boolean      :boolean
+    -- null boolean :boolean_three_with_default = #null
+    -- string       :string_with_default = little bunny foo foo
+    -- date         :date_with_default = 14 jul 2015
+    -- time         :time_with_default = 5:02 pm
+    -- datetime     :datetime_with_default = 14 jul 2015 5:02 pm
+    -- double       :double_with_default = 3.1415
+    -- string       :inet_with_default = 127.0.0.1/8
+    -- user_id      :user_id_with_default = system
+    -- post_id      :post_id_with_default = http://localhost:3000/t/adsfdsfajadsdafdsds-sf-awerjkldfdwe/21/1?u=system
+    -- topic_id     :topic_id_with_default = /t/-/21
+    -- int_list     :int_list_with_default = 1,2,3
+    -- string_list  :string_list_with_default = a,b,c
+    -- category_id  :category_id_with_default = meta
+    -- group_id     :group_id_with_default = admins
+    -- user_list    :mul_users_with_default = system,discobot
+    SELECT 1
+  SQL
+
+  fab!(:current_user) { Fabricate(:admin) }
+  fab!(:all_params_query) do
+    Fabricate(
+      :query,
+      name: "All params query",
+      description: "",
+      sql: ALL_PARAMS_SQL,
+      user: current_user,
+    )
+  end
+
+  before do
+    SiteSetting.data_explorer_enabled = true
+    sign_in(current_user)
+  end
+
+  it "correctly displays parameter input boxes" do
+    visit("/admin/plugins/explorer?id=#{all_params_query.id}")
+
+    ::DiscourseDataExplorer::Parameter
+      .create_from_sql(ALL_PARAMS_SQL)
+      .each { |param| expect(page).to have_css(".query-params [name=\"#{param.identifier}\"]") }
+  end
+end


### PR DESCRIPTION
What does this fix?
=============

We will dasherize category_id. The dasherize function accepts a string,
but we don't type-check it, so the default null may be passed in. This
will cause a type error and crash the front-end.

This commit fixes this situation.

See /t/134508

Screenshot
===========

![image](https://github.com/user-attachments/assets/987e01c9-98a0-4052-8123-f440981fc0e6)
