### PR TITLE
UX: Using CategoryChooser for param param_input

### DIFF
--- a/assets/javascripts/discourse/components/param-input.hbs
+++ b/assets/javascripts/discourse/components/param-input.hbs
@@ -64,6 +64,14 @@
     />
     <span class="param-name">{{@info.identifier}}</span>
 
+  {{else if (eq this.type "category_id")}}
+    <CategoryChooser
+      @value={{this.value}}
+      @onChange={{this.updateValue}}
+      name={{@info.identifier}}
+    />
+    <span class="param-name">{{@info.identifier}}</span>
+
   {{else}}
     <TextField
       @value={{this.value}}

--- a/assets/javascripts/discourse/components/param-input.js
+++ b/assets/javascripts/discourse/components/param-input.js
@@ -47,8 +47,6 @@ export default class ParamInput extends Component {
     const identifier = this.args.info.identifier;
     const initialValues = this.args.initialValues;
 
-    console.log(this.args);
-
     // access parsed params if present to update values to previously ran values
     if (initialValues && identifier in initialValues) {
       const initialValue = initialValues[identifier];

--- a/spec/system/param_input_spec.rb
+++ b/spec/system/param_input_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe "Param input", type: :system, js: true do
     ::DiscourseDataExplorer::Parameter
       .create_from_sql(ALL_PARAMS_SQL)
       .each do |param|
-        if !param.nullable && param.default.nil?
+        if !param.nullable && param.type != :boolean && param.default.nil?
           expect(page).to have_css(".query-params .param.invalid [name=\"#{param.identifier}\"]")
         else
           expect(page).to have_css(".query-params .param.valid [name=\"#{param.identifier}\"]")

--- a/spec/system/param_input_spec.rb
+++ b/spec/system/param_input_spec.rb
@@ -63,6 +63,12 @@ RSpec.describe "Param input", type: :system, js: true do
 
     ::DiscourseDataExplorer::Parameter
       .create_from_sql(ALL_PARAMS_SQL)
-      .each { |param| expect(page).to have_css(".query-params [name=\"#{param.identifier}\"]") }
+      .each do |param|
+        if !param.nullable && param.default.nil?
+          expect(page).to have_css(".query-params .param.invalid [name=\"#{param.identifier}\"]")
+        else
+          expect(page).to have_css(".query-params .param.valid [name=\"#{param.identifier}\"]")
+        end
+      end
   end
 end

--- a/test/javascripts/components/param-input-test.js
+++ b/test/javascripts/components/param-input-test.js
@@ -1,0 +1,42 @@
+import { render } from "@ember/test-helpers";
+import hbs from "htmlbars-inline-precompile";
+import { module, test } from "qunit";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import selectKit from "discourse/tests/helpers/select-kit-helper";
+
+const values = {};
+function updateParams(identifier, value) {
+  values[identifier] = value;
+}
+
+module("Data Explorer Plugin | Component | param-input", function (hooks) {
+  setupRenderingTest(hooks);
+
+  test("Renders the categroy_id type correctly", async function (assert) {
+    this.setProperties({
+      info: {
+        identifier: "category_id",
+        type: "category_id",
+        default: null,
+        nullable: false,
+      },
+      initialValues: {},
+      params: {},
+      updateParams,
+    });
+
+    await render(hbs`<ParamInput
+      @params={{this.params}}
+      @initialValues={{this.initialValues}}
+      @info={{this.info}}
+      @updateParams={{this.updateParams}}
+    />`);
+
+    const categoryChooser = selectKit(".category-chooser");
+
+    await categoryChooser.expand();
+    await categoryChooser.selectRowByValue(2);
+
+    assert.strictEqual(values.category_id, "2");
+  });
+});


### PR DESCRIPTION
This change changes the category_id input to use CategoryChooser instead of a bare text input to improve the user experience.

Related meta link: https://meta.discourse.org/t/wishlist-param-dropdown-for-data-explorer-query/253883/28

## Screenshot:

![image](https://github.com/user-attachments/assets/412e590a-8329-49bb-a874-1e5c4b671ad7)
