### PR TITLE
FIX: Use with_deleted only in topic and post

### DIFF
--- a/lib/discourse_data_explorer/parameter.rb
+++ b/lib/discourse_data_explorer/parameter.rb
@@ -193,7 +193,13 @@ module ::DiscourseDataExplorer
         if string.gsub(/[ _]/, "") =~ /^-?\d+$/
           klass_name = (/^(.*)_id$/.match(type.to_s)[1].classify.to_sym)
           begin
-            object = Object.const_get(klass_name).with_deleted.find(string.gsub(/[ _]/, "").to_i)
+            finder =
+              if type == :post_id || type == :topic_id
+                Object.const_get(klass_name).with_deleted
+              else
+                Object.const_get(klass_name)
+              end
+            object = finder.find(string.gsub(/[ _]/, "").to_i)
             value = object.id
           rescue ActiveRecord::RecordNotFound
             invalid_format string, "The specified #{klass_name} was not found"

--- a/spec/lib/parameter_spec.rb
+++ b/spec/lib/parameter_spec.rb
@@ -58,5 +58,23 @@ RSpec.describe DiscourseDataExplorer::Parameter do
         end
       end
     end
+
+    describe "group_id type" do
+      fab!(:group)
+
+      context "when the value provided is an integer" do
+        it "raises an error if no such group exists" do
+          expect { param("group_id", :group_id, nil, false).cast_to_ruby("-999") }.to raise_error(
+            ::DiscourseDataExplorer::ValidationError,
+          )
+        end
+
+        it "returns the group id if the group exists" do
+          expect(param("group_id", :group_id, nil, false).cast_to_ruby(group.id.to_s)).to eq(
+            group.id,
+          )
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
What does this fix?
=============

We used `with_deleted` incorrectly in the code. This method does not exist on `User`, `Badge`, and `Group`. This will cause an error when entering a numeric id in these three parameter input, forcing the user to enter the name/username of these inputs.

See https://github.com/discourse/discourse-data-explorer/pull/307#issuecomment-2291017256

Before:
======

![image](https://github.com/user-attachments/assets/943f479e-7529-46e0-a940-2b39c2a7ea4e)

After:
========
![image](https://github.com/user-attachments/assets/c15d529f-3ca9-4e10-9a7f-224c0da21bb2)
