### PR TITLE
FIX: Empty param-form should reject submit

### DIFF
--- a/assets/javascripts/discourse/components/param-input-form.gjs
+++ b/assets/javascripts/discourse/components/param-input-form.gjs
@@ -278,6 +278,7 @@ export default class ParamInputForm extends Component {
     if (this.form == null) {
       throw "No form";
     }
+    this.serializedData = null;
     await this.form.submit();
     if (this.serializedData == null) {
       throw new ParamValidationError("validation_failed");
@@ -293,7 +294,6 @@ export default class ParamInputForm extends Component {
 
   @action
   onSubmit(data) {
-    this.serializedData = null;
     const serializedData = {};
     for (const [id, val] of Object.entries(data)) {
       serializedData[id] =

--- a/assets/javascripts/discourse/controllers/group-reports-show.js
+++ b/assets/javascripts/discourse/controllers/group-reports-show.js
@@ -91,7 +91,7 @@ export default class GroupReportsShowController extends Controller {
     } catch (error) {
       if (error.jqXHR?.status === 422 && error.jqXHR.responseJSON) {
         this.results = error.jqXHR.responseJSON;
-      } else if (error instanceof ParamValidationError) {
+      } else if (!(error instanceof ParamValidationError)) {
         popupAjaxError(error);
       }
     } finally {

--- a/test/javascripts/components/param-input-test.js
+++ b/test/javascripts/components/param-input-test.js
@@ -194,5 +194,11 @@ module("Data Explorer Plugin | Component | param-input", function (hooks) {
     />`);
 
     assert.rejects(this.submit());
+
+    // After successfully submitting the test once, edit and submit again.
+    await fillIn(`[name="string"]`, "foo");
+    await this.submit();
+    await fillIn(`[name="string"]`, "");
+    assert.rejects(this.submit());
   });
 });

--- a/test/javascripts/components/param-input-test.js
+++ b/test/javascripts/components/param-input-test.js
@@ -169,4 +169,30 @@ module("Data Explorer Plugin | Component | param-input", function (hooks) {
       });
     }
   }
+
+  test("empty form will reject submit", async function (assert) {
+    this.setProperties({
+      param_info: [
+        {
+          identifier: "string",
+          type: "string",
+          default: null,
+          nullable: false,
+        },
+      ],
+      initialValues: {},
+      onRegisterApi: ({ submit }) => {
+        this.submit = submit;
+      },
+    });
+
+    await render(hbs`
+    <ParamInputForm
+      @initialValues={{this.initialValues}}
+      @paramInfo={{this.param_info}}
+      @onRegisterApi={{this.onRegisterApi}}
+    />`);
+
+    assert.rejects(this.submit());
+  });
 });


### PR DESCRIPTION
The `onSubmit` hook will only be triggered when the form is valid, so we
need to clear the contents of `serializedData` in advance in `submit`.
Otherwise, it may not throw a validation error.