### PR TITLE
FIX: Param should be displayed when the default value is invalid

### DIFF
--- a/lib/discourse_data_explorer/parameter.rb
+++ b/lib/discourse_data_explorer/parameter.rb
@@ -4,7 +4,7 @@ module ::DiscourseDataExplorer
   class Parameter
     attr_accessor :identifier, :type, :default, :nullable
 
-    def initialize(identifier, type, default, nullable)
+    def initialize(identifier, type, default, nullable, validate: true)
       unless identifier
         raise ValidationError.new("Parameter declaration error - identifier is missing")
       end
@@ -25,7 +25,7 @@ module ::DiscourseDataExplorer
       @default = default
       @nullable = nullable
       begin
-        cast_to_ruby default if default.present?
+        cast_to_ruby default if default.present? && validate
       rescue ValidationError
         raise ValidationError.new(
                 "Parameter declaration error - the default value is not a valid #{type}",
@@ -89,7 +89,7 @@ module ::DiscourseDataExplorer
             type = type.strip
 
             begin
-              ret_params << Parameter.new(ident, type, default, nullable)
+              ret_params << Parameter.new(ident, type, default, nullable, validate: opts[:strict])
             rescue StandardError
               raise if opts[:strict]
             end

--- a/spec/lib/parameter_spec.rb
+++ b/spec/lib/parameter_spec.rb
@@ -77,4 +77,22 @@ RSpec.describe DiscourseDataExplorer::Parameter do
       end
     end
   end
+
+  describe ".create_from_sql" do
+    it "should not validate default value" do
+      TEST_SQL = <<~SQL
+        -- [params]
+        -- user_id      :user_id = user_not_exists
+        -- post_id      :post_id = /t/should-not-exist/33554432/1
+        -- topic_id     :topic_id = /t/should-not-exist/2147483646
+        -- category_id  :category_id = category_not_exists
+        -- group_id     :group_id = group_not_exists
+        -- group_list   :group_list = group_not_exists1,group_not_exists1
+        -- user_list    :mul_users = user_not_exists1,user_not_exists2
+        SELECT 1
+      SQL
+
+      expect(described_class.create_from_sql(TEST_SQL).length).to eq(7)
+    end
+  end
 end


### PR DESCRIPTION
What's the problem?
===================

TL;DR: When the user enters an incorrect default value, its corresponding param-input will disappear

When creating a parameter from SQL, we perform cast_to_ruby, which means that if the default value given by the user is invalid, we will throw a ValidationError so the entire parameter will not be added to the param_list of the query. This behavior is very confusing, and users will not understand why an incorrect initial value will cause the param-input to disappear.

What's the fix?
================

The cast_to_ruby process is canceled in create_from_sql, so that param-input with incorrect default value will still be displayed. We have a simple validation process on the front end, which is enough to prompt whether some default inputs are incorrect.

Screenshot
=========

before:

![image](https://github.com/user-attachments/assets/09bf861f-8748-4cd0-8eaf-c7a2a8755cf4)


after:

![image](https://github.com/user-attachments/assets/9dd68b41-ec35-4ab8-9795-54d36b82297b)
