### PR TITLE
FIX: fix double validation

### DIFF
--- a/lib/discourse_data_explorer/parameter.rb
+++ b/lib/discourse_data_explorer/parameter.rb
@@ -153,16 +153,16 @@ module ::DiscourseDataExplorer
           invalid_format string, e.message
         end
       when :double
-        if string =~ /-?\d*(\.\d+)/
+        if string.strip =~ /^-?\d*\.?\d+$/
           value = Float(string)
         elsif string =~ /^(-?)Inf(inity)?$/i
-          if $1
+          if $1.present?
             value = -Float::INFINITY
           else
             value = Float::INFINITY
           end
         elsif string =~ /^(-?)NaN$/i
-          if $1
+          if $1.present?
             value = -Float::NAN
           else
             value = Float::NAN

--- a/spec/lib/parameter_spec.rb
+++ b/spec/lib/parameter_spec.rb
@@ -16,6 +16,26 @@ RSpec.describe DiscourseDataExplorer::Parameter do
       )
     end
 
+    describe "double type" do
+      let!(:double_param) { param("double", :double, nil, false) }
+
+      it "raises an error if not a double" do
+        expect { double_param.cast_to_ruby("abcd") }.to raise_error(
+          ::DiscourseDataExplorer::ValidationError,
+        )
+      end
+
+      it "returns the float number if it can be a valid double" do
+        expect(double_param.cast_to_ruby("3.14")).to eq(3.14)
+        expect(double_param.cast_to_ruby(".314")).to eq(0.314)
+        expect(double_param.cast_to_ruby("1")).to eq(1.0)
+        expect(double_param.cast_to_ruby("Inf")).to eq(Float::INFINITY)
+        expect(double_param.cast_to_ruby("-Infinity")).to eq(-Float::INFINITY)
+        expect(double_param.cast_to_ruby("-NaN").nan?).to eq(true)
+        expect(double_param.cast_to_ruby("NaN").nan?).to eq(true)
+      end
+    end
+
     describe "post_id type" do
       fab!(:post)
 


### PR DESCRIPTION
The old float validation had several bugs. It will recognize strings like "a1.2" and "3.4b" as valid doubles, but will not recognize integers like "1234" as doubles. Also, since an empty string is not falsy in Ruby, it will recognize "Inf" as -Infinity.

This commit fixes these bugs