### PR TITLE
DEV: Update ace-editor usage

### DIFF
--- a/assets/javascripts/discourse/templates/admin/plugins-explorer.hbs
+++ b/assets/javascripts/discourse/templates/admin/plugins-explorer.hbs
@@ -124,10 +124,11 @@
               <div class="panels-flex">
                 <div class="editor-panel">
                   <AceEditor
+                    {{on "click" this.setDirty}}
                     @content={{this.selectedItem.sql}}
+                    @onChange={{fn (mut this.selectedItem.sql)}}
                     @mode="sql"
                     @disabled={{this.selectedItem.destroyed}}
-                    {{on "click" this.setDirty}}
                     @save={{this.save}}
                     @submit={{this.saveAndRun}}
                   />


### PR DESCRIPTION
AceEditor is now a glimmer component (see: https://github.com/discourse/discourse/pull/28492) and it follows the "data down, actions up" pattern.