### PR TITLE
DEV: Fix autoloading

### DIFF
--- a/lib/discourse_data_explorer/data_explorer.rb
+++ b/lib/discourse_data_explorer/data_explorer.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
 module ::DiscourseDataExplorer
-  class ValidationError < StandardError
-  end
-
   module DataExplorer
     # Used for ftype calls, see https://www.rubydoc.info/gems/pg/0.17.1/PG%2FResult:ftype
     # and /usr/include/postgresql/server/catalog/pg_type_d.h

--- a/lib/discourse_data_explorer/validation_error.rb
+++ b/lib/discourse_data_explorer/validation_error.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module ::DiscourseDataExplorer
+  class ValidationError < StandardError
+  end
+end


### PR DESCRIPTION
A follow-up to e23c31195b097223f030800614b55d09bf54d086

Fixes errors like:
```
NameError:
       uninitialized constant DiscourseDataExplorer::ValidationError
     # ./plugins/discourse-data-explorer/spec/lib/parameter_spec.rb:15:in `block (3 levels) in <main>'
```