### PR TITLE
UX: Automatically convert to lowercase in explorer-schema

### DIFF
--- a/assets/javascripts/discourse/components/explorer-schema.js
+++ b/assets/javascripts/discourse/components/explorer-schema.js
@@ -114,7 +114,7 @@ export default class ExplorerSchema extends Component {
 
   @debounce(500)
   updateFilter(value) {
-    this.filter = value;
+    this.filter = value.toLowerCase();
     this.loading = false;
   }
 

--- a/test/javascripts/components/explorer-schema-test.js
+++ b/test/javascripts/components/explorer-schema-test.js
@@ -1,0 +1,60 @@
+import { fillIn, render } from "@ember/test-helpers";
+import hbs from "htmlbars-inline-precompile";
+import { module, test } from "qunit";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+
+const schema = {
+  posts: [
+    {
+      column_name: "id",
+      data_type: "serial",
+      primary: true,
+      notes: "primary key",
+      havetypeinfo: true,
+    },
+    {
+      column_name: "raw",
+      data_type: "text",
+      column_desc: "The raw Markdown that the user entered into the composer.",
+      havepopup: true,
+      havetypeinfo: true,
+    },
+  ],
+  categories: [
+    {
+      column_name: "id",
+      data_type: "serial",
+      primary: true,
+      notes: "primary key",
+      havetypeinfo: true,
+    },
+    {
+      column_name: "name",
+      data_type: "varchar(50)",
+      havetypeinfo: false,
+    },
+  ],
+};
+
+module("Data Explorer Plugin | Component | explorer-schema", function (hooks) {
+  setupRenderingTest(hooks);
+
+  test("will automatically convert to lowercase", async function (assert) {
+    this.setProperties({
+      schema,
+      hideSchema: false,
+      updateHideSchema: () => {},
+    });
+
+    await render(hbs`
+    <ExplorerSchema
+      @schema={{this.schema}}
+      @hideSchema={{this.hideSchema}}
+      @updateHideSchema={{this.updateHideSchema}}
+    />`);
+
+    await fillIn(`.schema-search input`, "Cat");
+
+    assert.dom(".schema-table").exists();
+  });
+});

--- a/test/javascripts/components/explorer-schema-test.js
+++ b/test/javascripts/components/explorer-schema-test.js
@@ -56,5 +56,9 @@ module("Data Explorer Plugin | Component | explorer-schema", function (hooks) {
     await fillIn(`.schema-search input`, "Cat");
 
     assert.dom(".schema-table").exists();
+
+    await fillIn(`.schema-search input`, "NotExist");
+
+    assert.dom(".schema-table").doesNotExist();
   });
 });


### PR DESCRIPTION
In the past, ExplorerSchema searches were case-sensitive, so if the user's input method capitalized the first letter, it was likely that no results would be found.

The new change allows you to enter uppercase letters, which will automatically be converted to lowercase when searching.

meta topic: https://meta.discourse.org/t/can-the-data-explorer-search-input-be-converted-to-lower-case/323435


## Screenshot

![image](https://github.com/user-attachments/assets/76681dcd-d6d2-4b6b-a109-ebddb95abf3f)
