### PR TITLE
FEATURE: Add script to post report results in a topic regularly

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -118,3 +118,15 @@ en:
               label: Skip sending PM if there are no results
             attach_csv:
               label: Attach the CSV file to the PM
+        recurring_data_explorer_result_topic:
+          fields:
+            topic_id:
+              label: The topic to post query results in
+            query_id:
+              label: Data Explorer Query
+            query_params:
+              label: Data Explorer Query parameters
+            skip_empty:
+              label: Skip posting if there are no results
+            attach_csv:
+              label: Attach the CSV file to the post

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -6,3 +6,6 @@ en:
       recurring_data_explorer_result_pm:
         title: Schedule a PM with Data Explorer results
         description: Get scheduled reports sent to your messages each month
+      recurring_data_explorer_result_topic:
+        title: Schedule a post in a topic with Data Explorer results
+        description: Get scheduled reports posted to a specific topic each month

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -5,7 +5,34 @@ en:
     scriptables:
       recurring_data_explorer_result_pm:
         title: Schedule a PM with Data Explorer results
-        description: Get scheduled reports sent to your messages each month
+        description: Get scheduled reports sent to your messages
       recurring_data_explorer_result_topic:
         title: Schedule a post in a topic with Data Explorer results
-        description: Get scheduled reports posted to a specific topic each month
+        description: Get scheduled reports posted to a specific topic
+  data_explorer:
+    report_generator:
+      private_message:
+        title: "Scheduled report for %{query_name}"
+        body: |
+          Hi %{recipient_name}, your Data Explorer report is ready.
+
+          Query name:
+          %{query_name}
+
+          Here are the results:
+          %{table}
+
+          <a href='%{base_url}/admin/plugins/explorer?id=%{query_id}'>View query in Data Explorer</a>
+
+          Report created at %{created_at} (%{timezone})
+      post:
+        body: |
+          ### Scheduled report for %{query_name}
+
+          Here are the results:
+          %{table}
+
+          <a href='%{base_url}/admin/plugins/explorer?id=%{query_id}'>View query in Data Explorer</a>
+
+          Report created at %{created_at} (%{timezone})
+      upload_appendix: "Appendix: [%{filename}|attachment](%{short_url})"

--- a/lib/discourse_data_explorer/report_generator.rb
+++ b/lib/discourse_data_explorer/report_generator.rb
@@ -18,6 +18,21 @@ module ::DiscourseDataExplorer
       build_report_pms(query, table, recipients, attach_csv: opts[:attach_csv], result:)
     end
 
+    def self.generate_post(query_id, query_params, opts = {})
+      query = DiscourseDataExplorer::Query.find(query_id)
+      return {} if !query
+
+      params = params_to_hash(query_params)
+
+      result = DataExplorer.run_query(query, params)
+      query.update!(last_run_at: Time.now)
+
+      return {} if opts[:skip_empty] && result[:pg_result].values.empty?
+      table = ResultToMarkdown.convert(result[:pg_result])
+
+      build_report_post(query, table, attach_csv: opts[:attach_csv], result:)
+    end
+
     private
 
     def self.params_to_hash(query_params)
@@ -42,17 +57,7 @@ module ::DiscourseDataExplorer
 
     def self.build_report_pms(query, table = "", targets = [], attach_csv: false, result: nil)
       pms = []
-      upload =
-        if attach_csv
-          tmp_filename =
-            "#{query.slug}@#{Slug.for(Discourse.current_hostname, "discourse")}-#{Date.today}.dcqresult.csv"
-          tmp = Tempfile.new(tmp_filename)
-          tmp.write(ResultFormatConverter.convert(:csv, result))
-          tmp.rewind
-          UploadCreator.new(tmp, tmp_filename, type: "csv_export").create_for(
-            Discourse.system_user.id,
-          )
-        end
+      upload = create_csv_upload(query, result) if attach_csv
 
       targets.each do |target|
         name = target[0]
@@ -71,6 +76,33 @@ module ::DiscourseDataExplorer
         pms << pm
       end
       pms
+    end
+
+    def self.build_report_post(query, table = "", attach_csv: false, result: nil)
+      pms = []
+
+      upload = create_csv_upload(query, result) if attach_csv
+
+      post = {}
+      post["raw"] = "### Scheduled Report for #{query.name}\n\n" +
+        "Query Name:\n#{query.name}\n\nHere are the results:\n#{table}\n\n" +
+        "<a href='#{Discourse.base_url}/admin/plugins/explorer?id=#{query.id}'>View query in Data Explorer</a>\n\n" +
+        "Report created at #{Time.zone.now.strftime("%Y-%m-%d at %H:%M:%S")} (#{Time.zone.name})"
+
+      if upload
+        post["raw"] << "\n\nAppendix: [#{upload.original_filename}|attachment](#{upload.short_url})"
+      end
+
+      post
+    end
+
+    def self.create_csv_upload(query, result)
+      tmp_filename =
+        "#{query.slug}@#{Slug.for(Discourse.current_hostname, "discourse")}-#{Date.today}.dcqresult.csv"
+      tmp = Tempfile.new(tmp_filename)
+      tmp.write(ResultFormatConverter.convert(:csv, result))
+      tmp.rewind
+      UploadCreator.new(tmp, tmp_filename, type: "csv_export").create_for(Discourse.system_user.id)
     end
 
     def self.filter_recipients_by_query_access(recipients, query)

--- a/lib/discourse_data_explorer/report_generator.rb
+++ b/lib/discourse_data_explorer/report_generator.rb
@@ -64,14 +64,28 @@ module ::DiscourseDataExplorer
         pm_type = "target_#{target[1]}s"
 
         pm = {}
-        pm["title"] = "Scheduled Report for #{query.name}"
+        pm["title"] = I18n.t(
+          "data_explorer.report_generator.private_message.title",
+          query_name: query.name,
+        )
         pm[pm_type] = Array(name)
-        pm["raw"] = "Hi #{name}, your data explorer report is ready.\n\n" +
-          "Query Name:\n#{query.name}\n\nHere are the results:\n#{table}\n\n" +
-          "<a href='#{Discourse.base_url}/admin/plugins/explorer?id=#{query.id}'>View query in Data Explorer</a>\n\n" +
-          "Report created at #{Time.zone.now.strftime("%Y-%m-%d at %H:%M:%S")} (#{Time.zone.name})"
+        pm["raw"] = I18n.t(
+          "data_explorer.report_generator.private_message.body",
+          recipient_name: name,
+          query_name: query.name,
+          table: table,
+          base_url: Discourse.base_url,
+          query_id: query.id,
+          created_at: Time.zone.now.strftime("%Y-%m-%d at %H:%M:%S"),
+          timezone: Time.zone.name,
+        )
         if upload
-          pm["raw"] << "\n\nAppendix: [#{upload.original_filename}|attachment](#{upload.short_url})"
+          pm["raw"] << "\n\n" +
+            I18n.t(
+              "data_explorer.report_generator.upload_appendix",
+              filename: upload.original_filename,
+              short_url: upload.short_url,
+            )
         end
         pms << pm
       end
@@ -79,18 +93,27 @@ module ::DiscourseDataExplorer
     end
 
     def self.build_report_post(query, table = "", attach_csv: false, result: nil)
-      pms = []
-
       upload = create_csv_upload(query, result) if attach_csv
 
       post = {}
-      post["raw"] = "### Scheduled Report for #{query.name}\n\n" +
-        "Query Name:\n#{query.name}\n\nHere are the results:\n#{table}\n\n" +
-        "<a href='#{Discourse.base_url}/admin/plugins/explorer?id=#{query.id}'>View query in Data Explorer</a>\n\n" +
-        "Report created at #{Time.zone.now.strftime("%Y-%m-%d at %H:%M:%S")} (#{Time.zone.name})"
+      post["raw"] = I18n.t(
+        "data_explorer.report_generator.post.body",
+        recipient_name: name,
+        query_name: query.name,
+        table: table,
+        base_url: Discourse.base_url,
+        query_id: query.id,
+        created_at: Time.zone.now.strftime("%Y-%m-%d at %H:%M:%S"),
+        timezone: Time.zone.name,
+      )
 
       if upload
-        post["raw"] << "\n\nAppendix: [#{upload.original_filename}|attachment](#{upload.short_url})"
+        post["raw"] << "\n\n" +
+          I18n.t(
+            "data_explorer.report_generator.upload_appendix",
+            filename: upload.original_filename,
+            short_url: upload.short_url,
+          )
       end
 
       post

--- a/spec/fabricators/query_fabricator.rb
+++ b/spec/fabricators/query_fabricator.rb
@@ -3,7 +3,7 @@
 Fabricator(:query, from: DiscourseDataExplorer::Query) do
   name { sequence(:name) { |i| "cat#{i}" } }
   description { sequence(:desc) { |i| "description #{i}" } }
-  sql { sequence(:sql) { |i| "SELECT * FROM users limit #{i}" } }
+  sql { sequence(:sql) { |i| "SELECT * FROM users WHERE id > 0 LIMIT #{i}" } }
   user
 end
 

--- a/spec/report_generator_spec.rb
+++ b/spec/report_generator_spec.rb
@@ -12,7 +12,10 @@ describe DiscourseDataExplorer::ReportGenerator do
 
   let(:query_params) { [%w[from_days_ago 0], %w[duration_days 15]] }
 
-  before { SiteSetting.data_explorer_enabled = true }
+  before do
+    SiteSetting.data_explorer_enabled = true
+    SiteSetting.authorized_extensions = "csv"
+  end
 
   describe ".generate" do
     it "returns [] if the recipient is not in query group" do
@@ -37,13 +40,23 @@ describe DiscourseDataExplorer::ReportGenerator do
       expect(result).to eq(
         [
           {
-            "title" => "Scheduled Report for #{query.name}",
+            "title" =>
+              I18n.t(
+                "data_explorer.report_generator.private_message.title",
+                query_name: query.name,
+              ),
             "target_usernames" => [user.username],
             "raw" =>
-              "Hi #{user.username}, your data explorer report is ready.\n\n" +
-                "Query Name:\n#{query.name}\n\nHere are the results:\nle table\n\n" +
-                "<a href='#{Discourse.base_url}/admin/plugins/explorer?id=#{query.id}'>View query in Data Explorer</a>\n\n" +
-                "Report created at #{Time.zone.now.strftime("%Y-%m-%d at %H:%M:%S")} (#{Time.zone.name})",
+              I18n.t(
+                "data_explorer.report_generator.private_message.body",
+                recipient_name: user.username,
+                query_name: query.name,
+                table: "le table",
+                base_url: Discourse.base_url,
+                query_id: query.id,
+                created_at: Time.zone.now.strftime("%Y-%m-%d at %H:%M:%S"),
+                timezone: Time.zone.name,
+              ),
           },
         ],
       )
@@ -57,17 +70,26 @@ describe DiscourseDataExplorer::ReportGenerator do
       freeze_time
 
       result = described_class.generate(query.id, query_params, [group.name, "non-existent-group"])
-
       expect(result).to eq(
         [
           {
-            "title" => "Scheduled Report for #{query.name}",
+            "title" =>
+              I18n.t(
+                "data_explorer.report_generator.private_message.title",
+                query_name: query.name,
+              ),
             "target_group_names" => [group.name],
             "raw" =>
-              "Hi #{group.name}, your data explorer report is ready.\n\n" +
-                "Query Name:\n#{query.name}\n\nHere are the results:\nle table\n\n" +
-                "<a href='#{Discourse.base_url}/admin/plugins/explorer?id=#{query.id}'>View query in Data Explorer</a>\n\n" +
-                "Report created at #{Time.zone.now.strftime("%Y-%m-%d at %H:%M:%S")} (#{Time.zone.name})",
+              I18n.t(
+                "data_explorer.report_generator.private_message.body",
+                recipient_name: group.name,
+                query_name: query.name,
+                table: "le table",
+                base_url: Discourse.base_url,
+                query_id: query.id,
+                created_at: Time.zone.now.strftime("%Y-%m-%d at %H:%M:%S"),
+                timezone: Time.zone.name,
+              ),
           },
         ],
       )
@@ -83,20 +105,30 @@ describe DiscourseDataExplorer::ReportGenerator do
       expect(result).to eq(
         [
           {
-            "title" => "Scheduled Report for #{query.name}",
+            "title" =>
+              I18n.t(
+                "data_explorer.report_generator.private_message.title",
+                query_name: query.name,
+              ),
             "target_emails" => [email],
             "raw" =>
-              "Hi #{email}, your data explorer report is ready.\n\n" +
-                "Query Name:\n#{query.name}\n\nHere are the results:\nle table\n\n" +
-                "<a href='#{Discourse.base_url}/admin/plugins/explorer?id=#{query.id}'>View query in Data Explorer</a>\n\n" +
-                "Report created at #{Time.zone.now.strftime("%Y-%m-%d at %H:%M:%S")} (#{Time.zone.name})",
+              I18n.t(
+                "data_explorer.report_generator.private_message.body",
+                recipient_name: email,
+                query_name: query.name,
+                table: "le table",
+                base_url: Discourse.base_url,
+                query_id: query.id,
+                created_at: Time.zone.now.strftime("%Y-%m-%d at %H:%M:%S"),
+                timezone: Time.zone.name,
+              ),
           },
         ],
       )
     end
 
     it "works with duplicate recipients" do
-      DiscourseDataExplorer::ResultToMarkdown.expects(:convert).returns("table data")
+      DiscourseDataExplorer::ResultToMarkdown.expects(:convert).returns("le table")
       freeze_time
 
       result = described_class.generate(query.id, query_params, [user.username, user.username])
@@ -104,13 +136,23 @@ describe DiscourseDataExplorer::ReportGenerator do
       expect(result).to eq(
         [
           {
-            "title" => "Scheduled Report for #{query.name}",
+            "title" =>
+              I18n.t(
+                "data_explorer.report_generator.private_message.title",
+                query_name: query.name,
+              ),
             "target_usernames" => [user.username],
             "raw" =>
-              "Hi #{user.username}, your data explorer report is ready.\n\n" +
-                "Query Name:\n#{query.name}\n\nHere are the results:\ntable data\n\n" +
-                "<a href='#{Discourse.base_url}/admin/plugins/explorer?id=#{query.id}'>View query in Data Explorer</a>\n\n" +
-                "Report created at #{Time.zone.now.strftime("%Y-%m-%d at %H:%M:%S")} (#{Time.zone.name})",
+              I18n.t(
+                "data_explorer.report_generator.private_message.body",
+                recipient_name: user.username,
+                query_name: query.name,
+                table: "le table",
+                base_url: Discourse.base_url,
+                query_id: query.id,
+                created_at: Time.zone.now.strftime("%Y-%m-%d at %H:%M:%S"),
+                timezone: Time.zone.name,
+              ),
           },
         ],
       )
@@ -118,7 +160,7 @@ describe DiscourseDataExplorer::ReportGenerator do
 
     it "works with multiple recipient types" do
       Fabricate(:query_group, query: query, group: group)
-      DiscourseDataExplorer::ResultToMarkdown.expects(:convert).returns("table data")
+      DiscourseDataExplorer::ResultToMarkdown.expects(:convert).returns("le table")
 
       result =
         described_class.generate(
@@ -144,12 +186,22 @@ describe DiscourseDataExplorer::ReportGenerator do
       filename =
         "#{query.slug}@#{Slug.for(Discourse.current_hostname, "discourse")}-#{Date.today}.dcqresult.csv"
 
-      expect(result[0]["raw"]).to include(
-        "Hi #{user.username}, your data explorer report is ready.\n\n" +
-          "Query Name:\n#{query.name}\n\nHere are the results:\nle table\n\n" +
-          "<a href='#{Discourse.base_url}/admin/plugins/explorer?id=#{query.id}'>View query in Data Explorer</a>\n\n" +
-          "Report created at #{Time.zone.now.strftime("%Y-%m-%d at %H:%M:%S")} (#{Time.zone.name})\n\n" +
-          "Appendix: [#{filename}|attachment](upload://",
+      expect(result[0]["raw"]).to eq(
+        I18n.t(
+          "data_explorer.report_generator.private_message.body",
+          recipient_name: user.username,
+          query_name: query.name,
+          table: "le table",
+          base_url: Discourse.base_url,
+          query_id: query.id,
+          created_at: Time.zone.now.strftime("%Y-%m-%d at %H:%M:%S"),
+          timezone: Time.zone.name,
+        ) + "\n\n" +
+          I18n.t(
+            "data_explorer.report_generator.upload_appendix",
+            filename: filename,
+            short_url: Upload.find_by(original_filename: filename).short_url,
+          ),
       )
     end
   end
@@ -161,16 +213,17 @@ describe DiscourseDataExplorer::ReportGenerator do
 
       result = described_class.generate_post(query.id, query_params)
 
-      filename =
-        "#{query.slug}@#{Slug.for(Discourse.current_hostname, "discourse")}-#{Date.today}.dcqresult.csv"
-
-      expect(result["raw"]).to include(
-        "### Scheduled Report for Most Common Likers\n\n" +
-          "Query Name:\n#{query.name}\n\nHere are the results:\nle table\n\n" +
-          "<a href='#{Discourse.base_url}/admin/plugins/explorer?id=#{query.id}'>View query in Data Explorer</a>\n\n" +
-          "Report created at #{Time.zone.now.strftime("%Y-%m-%d at %H:%M:%S")} (#{Time.zone.name})",
+      expect(result["raw"]).to eq(
+        I18n.t(
+          "data_explorer.report_generator.post.body",
+          query_name: query.name,
+          table: "le table",
+          base_url: Discourse.base_url,
+          query_id: query.id,
+          created_at: Time.zone.now.strftime("%Y-%m-%d at %H:%M:%S"),
+          timezone: Time.zone.name,
+        ),
       )
-      expect(result["raw"]).not_to include("Appendix")
     end
 
     it "works with attached csv file" do
@@ -182,12 +235,21 @@ describe DiscourseDataExplorer::ReportGenerator do
       filename =
         "#{query.slug}@#{Slug.for(Discourse.current_hostname, "discourse")}-#{Date.today}.dcqresult.csv"
 
-      expect(result["raw"]).to include(
-        "### Scheduled Report for Most Common Likers\n\n" +
-          "Query Name:\n#{query.name}\n\nHere are the results:\nle table\n\n" +
-          "<a href='#{Discourse.base_url}/admin/plugins/explorer?id=#{query.id}'>View query in Data Explorer</a>\n\n" +
-          "Report created at #{Time.zone.now.strftime("%Y-%m-%d at %H:%M:%S")} (#{Time.zone.name})\n\n" +
-          "Appendix: [#{filename}|attachment](upload://",
+      expect(result["raw"]).to eq(
+        I18n.t(
+          "data_explorer.report_generator.post.body",
+          query_name: query.name,
+          table: "le table",
+          base_url: Discourse.base_url,
+          query_id: query.id,
+          created_at: Time.zone.now.strftime("%Y-%m-%d at %H:%M:%S"),
+          timezone: Time.zone.name,
+        ) + "\n\n" +
+          I18n.t(
+            "data_explorer.report_generator.upload_appendix",
+            filename: filename,
+            short_url: Upload.find_by(original_filename: filename).short_url,
+          ),
       )
     end
   end

--- a/spec/report_generator_spec.rb
+++ b/spec/report_generator_spec.rb
@@ -153,4 +153,42 @@ describe DiscourseDataExplorer::ReportGenerator do
       )
     end
   end
+
+  describe ".generate_post" do
+    it "works without attached csv file" do
+      DiscourseDataExplorer::ResultToMarkdown.expects(:convert).returns("le table")
+      freeze_time
+
+      result = described_class.generate_post(query.id, query_params)
+
+      filename =
+        "#{query.slug}@#{Slug.for(Discourse.current_hostname, "discourse")}-#{Date.today}.dcqresult.csv"
+
+      expect(result["raw"]).to include(
+        "### Scheduled Report for Most Common Likers\n\n" +
+          "Query Name:\n#{query.name}\n\nHere are the results:\nle table\n\n" +
+          "<a href='#{Discourse.base_url}/admin/plugins/explorer?id=#{query.id}'>View query in Data Explorer</a>\n\n" +
+          "Report created at #{Time.zone.now.strftime("%Y-%m-%d at %H:%M:%S")} (#{Time.zone.name})",
+      )
+      expect(result["raw"]).not_to include("Appendix")
+    end
+
+    it "works with attached csv file" do
+      DiscourseDataExplorer::ResultToMarkdown.expects(:convert).returns("le table")
+      freeze_time
+
+      result = described_class.generate_post(query.id, query_params, { attach_csv: true })
+
+      filename =
+        "#{query.slug}@#{Slug.for(Discourse.current_hostname, "discourse")}-#{Date.today}.dcqresult.csv"
+
+      expect(result["raw"]).to include(
+        "### Scheduled Report for Most Common Likers\n\n" +
+          "Query Name:\n#{query.name}\n\nHere are the results:\nle table\n\n" +
+          "<a href='#{Discourse.base_url}/admin/plugins/explorer?id=#{query.id}'>View query in Data Explorer</a>\n\n" +
+          "Report created at #{Time.zone.now.strftime("%Y-%m-%d at %H:%M:%S")} (#{Time.zone.name})\n\n" +
+          "Appendix: [#{filename}|attachment](upload://",
+      )
+    end
+  end
 end


### PR DESCRIPTION
This script is similar to the existing one that schedules
report results to to be sent to a PM on a regular basis,
but instead takes a topic ID and posts to that. This way
people can have report results sent to a public topic regularly
too and not have to deal with PM recipients and so on.
