### PR TITLE
FIX: Optionally linkify URL columns server-side

### DIFF
--- a/assets/javascripts/discourse/components/query-row-content.js
+++ b/assets/javascripts/discourse/components/query-row-content.js
@@ -8,7 +8,7 @@ import TextViewComponent from "./result-types/text";
 export default class QueryRowContent extends Component {
   @cached
   get results() {
-    return this.args.columnComponents.map((t, idx) => {
+    return this.args.columnComponents.map((componentDefinition, idx) => {
       const value = this.args.row[idx],
         id = parseInt(value, 10);
 
@@ -23,19 +23,20 @@ export default class QueryRowContent extends Component {
           component: TextViewComponent,
           textValue: "NULL",
         };
-      } else if (t.name === "text") {
+      } else if (componentDefinition.name === "text") {
         return {
           component: TextViewComponent,
           textValue: escapeExpression(this.args.row[idx].toString()),
         };
       }
 
-      const lookupFunc = this.args[`lookup${capitalize(t.name)}`];
+      const lookupFunc =
+        this.args[`lookup${capitalize(componentDefinition.name)}`];
       if (lookupFunc) {
-        ctx[t.name] = lookupFunc.call(this.args, id);
+        ctx[componentDefinition.name] = lookupFunc.call(this.args, id);
       }
 
-      if (t.name === "url") {
+      if (componentDefinition.name === "url") {
         let [url, name] = guessUrl(value);
         ctx["href"] = url;
         ctx["target"] = name;
@@ -43,7 +44,7 @@ export default class QueryRowContent extends Component {
 
       try {
         return {
-          component: t.component || TextViewComponent,
+          component: componentDefinition.component || TextViewComponent,
           ctx,
         };
       } catch (e) {
@@ -53,10 +54,10 @@ export default class QueryRowContent extends Component {
   }
 }
 
-function guessUrl(t) {
-  let [dest, name] = [t, t];
+function guessUrl(columnValue) {
+  let [dest, name] = [columnValue, columnValue];
 
-  const split = t.split(/,(.+)/);
+  const split = columnValue.split(/,(.+)/);
 
   if (split.length > 1) {
     name = split[0];

--- a/lib/discourse_data_explorer/report_generator.rb
+++ b/lib/discourse_data_explorer/report_generator.rb
@@ -13,7 +13,8 @@ module ::DiscourseDataExplorer
       query.update!(last_run_at: Time.now)
 
       return [] if opts[:skip_empty] && result[:pg_result].values.empty?
-      table = ResultToMarkdown.convert(result[:pg_result])
+      table =
+        ResultToMarkdown.convert(result[:pg_result], render_url_columns: opts[:render_url_columns])
 
       build_report_pms(query, table, recipients, attach_csv: opts[:attach_csv], result:)
     end
@@ -28,7 +29,8 @@ module ::DiscourseDataExplorer
       query.update!(last_run_at: Time.now)
 
       return {} if opts[:skip_empty] && result[:pg_result].values.empty?
-      table = ResultToMarkdown.convert(result[:pg_result])
+      table =
+        ResultToMarkdown.convert(result[:pg_result], render_url_columns: opts[:render_url_columns])
 
       build_report_post(query, table, attach_csv: opts[:attach_csv], result:)
     end

--- a/lib/discourse_data_explorer/result_to_markdown.rb
+++ b/lib/discourse_data_explorer/result_to_markdown.rb
@@ -4,7 +4,7 @@ include HasSanitizableFields
 
 module ::DiscourseDataExplorer
   class ResultToMarkdown
-    def self.convert(pg_result, opts = {})
+    def self.convert(pg_result, render_url_columns = false)
       relations, colrender = DataExplorer.add_extra_data(pg_result)
       result_data = []
 
@@ -33,7 +33,7 @@ module ::DiscourseDataExplorer
             else
               row_data[col_index] = "#{related_row[column]} (#{col})"
             end
-          elsif col_render == "url" && opts[:render_url_columns]
+          elsif col_render == "url" && render_url_columns
             url, text = guess_url(col)
             row_data[col_index] = "[#{text}](#{url})"
           else
@@ -51,12 +51,7 @@ module ::DiscourseDataExplorer
     end
 
     def self.guess_url(column_value)
-      split = column_value.split(/,(.+)/)
-
-      if split.length > 1
-        text = split[0]
-        url = split[1]
-      end
+      text, url = column_value.split(/,(.+)/)
 
       [url || column_value, text || column_value]
     end

--- a/plugin.rb
+++ b/plugin.rb
@@ -105,7 +105,12 @@ after_initialize do
           end
 
           DiscourseDataExplorer::ReportGenerator
-            .generate(query_id, query_params, recipients, { skip_empty:, attach_csv: })
+            .generate(
+              query_id,
+              query_params,
+              recipients,
+              { skip_empty:, attach_csv:, render_url_columns: true },
+            )
             .each do |pm|
               begin
                 utils.send_pm(pm, automation_id: automation.id, prefers_encrypt: false)
@@ -153,7 +158,7 @@ after_initialize do
               DiscourseDataExplorer::ReportGenerator.generate_post(
                 query_id,
                 query_params,
-                { skip_empty:, attach_csv: },
+                { skip_empty:, attach_csv:, render_url_columns: true },
               )
 
             next if post.empty?


### PR DESCRIPTION
Followup da1c99ec2d272a4eac8586a8b61794e8b755619b

We already had the functionality to convert results like
this:

```
|blah_url|
|--------|
|3,https://test.com|
```

To a link clientside, so in the UI it looks like this:

```
<a href="https://test.com">3</a>
```

With the addition of the recurring report to post automation,
and the existing report to PM automation, we also need to be
able to do this server-side, so reports don't come out malformed
if they have these type of count + URL columns.

Now if one of the automations generates the report, we tell the report
generator and markdown renderer to create an actual markdown link
for these URL columns.
