### PR TITLE
UX: clarify the need for authorized extension

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -118,6 +118,7 @@ en:
               label: Skip sending PM if there are no results
             attach_csv:
               label: Attach the CSV file to the PM
+              description: Requires to add `csv` to the list of authorized extensions in the site settings
         recurring_data_explorer_result_topic:
           fields:
             topic_id:

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -118,7 +118,6 @@ en:
               label: Skip sending PM if there are no results
             attach_csv:
               label: Attach the CSV file to the PM
-              description: Requires to add `csv` to the list of authorized extensions in the site settings
         recurring_data_explorer_result_topic:
           fields:
             topic_id:

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -6,6 +6,7 @@ en:
       recurring_data_explorer_result_pm:
         title: Schedule a PM with Data Explorer results
         description: Get scheduled reports sent to your messages
+        no_csv_allowed: "When using `attach_csv` field, `csv` must be added to the list of authorized extensions in the site settings."
       recurring_data_explorer_result_topic:
         title: Schedule a post in a topic with Data Explorer results
         description: Get scheduled reports posted to a specific topic

--- a/plugin.rb
+++ b/plugin.rb
@@ -82,7 +82,15 @@ after_initialize do
         field :query_id, component: :choices, required: true, extra: { content: queries }
         field :query_params, component: :"key-value", accepts_placeholders: true
         field :skip_empty, component: :boolean
-        field :attach_csv, component: :boolean
+        field :attach_csv,
+              component: :boolean,
+              validator: ->(attach_csv) do
+                if attach_csv && !SiteSetting.authorized_extensions.split("|").include?("csv")
+                  I18n.t(
+                    "discourse_automation.scriptables.recurring_data_explorer_result_pm.no_csv_allowed",
+                  )
+                end
+              end
 
         version 1
         triggerables [:recurring]

--- a/plugin.rb
+++ b/plugin.rb
@@ -85,7 +85,10 @@ after_initialize do
         field :attach_csv,
               component: :boolean,
               validator: ->(attach_csv) do
-                if attach_csv && !SiteSetting.authorized_extensions.split("|").include?("csv")
+                return if !attach_csv
+
+                extensions = SiteSetting.authorized_extensions.split("|")
+                if (extensions & %w[csv *]).empty?
                   I18n.t(
                     "discourse_automation.scriptables.recurring_data_explorer_result_pm.no_csv_allowed",
                   )

--- a/spec/automation/recurring_data_explorer_result_pm_spec.rb
+++ b/spec/automation/recurring_data_explorer_result_pm_spec.rb
@@ -141,6 +141,12 @@ describe "RecurringDataExplorerResultPM" do
       expect {
         automation.upsert_field!("attach_csv", "boolean", { value: true })
       }.to_not raise_error
+
+      SiteSetting.authorized_extensions = "*"
+
+      expect {
+        automation.upsert_field!("attach_csv", "boolean", { value: true })
+      }.to_not raise_error
     end
   end
 end

--- a/spec/automation/recurring_data_explorer_result_pm_spec.rb
+++ b/spec/automation/recurring_data_explorer_result_pm_spec.rb
@@ -135,6 +135,12 @@ describe "RecurringDataExplorerResultPM" do
         ActiveRecord::RecordInvalid,
         /#{I18n.t("discourse_automation.scriptables.recurring_data_explorer_result_pm.no_csv_allowed")}/,
       )
+
+      SiteSetting.authorized_extensions = "pdf|txt|csv"
+
+      expect {
+        automation.upsert_field!("attach_csv", "boolean", { value: true })
+      }.to_not raise_error
     end
   end
 end

--- a/spec/automation/recurring_data_explorer_result_pm_spec.rb
+++ b/spec/automation/recurring_data_explorer_result_pm_spec.rb
@@ -126,4 +126,15 @@ describe "RecurringDataExplorerResultPM" do
       )
     end
   end
+
+  context "when using attach_csv" do
+    it "requires csv to be in authorized extensions" do
+      SiteSetting.authorized_extensions = "pdf|txt"
+
+      expect { automation.upsert_field!("attach_csv", "boolean", { value: true }) }.to raise_error(
+        ActiveRecord::RecordInvalid,
+        /#{I18n.t("discourse_automation.scriptables.recurring_data_explorer_result_pm.no_csv_allowed")}/,
+      )
+    end
+  end
 end


### PR DESCRIPTION
When checking `attach_csv` in the `Schedule a PM with Data Explorer results`
 automation script, `csv` has to be added to the list of authorized extensions in the site settings.

![Screenshot 2024-12-09 at 17 09 14](https://github.com/user-attachments/assets/65f158d4-3a1d-45aa-854a-e2f0ad68fe1f)

