### PR TITLE
FIX: boolean field default state mismatch

### DIFF
--- a/assets/javascripts/discourse/components/param-input-form.gjs
+++ b/assets/javascripts/discourse/components/param-input-form.gjs
@@ -194,10 +194,10 @@ export default class ParamInputForm extends Component {
       case "category_id":
         return digitalizeCategoryId(value);
       case "boolean":
-        if (value == null) {
+        if (value == null || value === "#null") {
           return info.nullable ? "#null" : false;
         }
-        return value;
+        return value === "true";
       case "group_id":
       case "group_list":
         const normalized = this.normalizeGroups(value);


### PR DESCRIPTION
When reading an existing state from the params defaults or from URL params, the input elements weren't representing the right state for booleans and "3-state/null booleans".

internal /t/-/118495