### PR TITLE
FIX: Query downloads were being passed an incorrect query object.

### DIFF
--- a/assets/javascripts/discourse/controllers/admin-plugins-explorer-index.js
+++ b/assets/javascripts/discourse/controllers/admin-plugins-explorer-index.js
@@ -151,11 +151,6 @@ export default class PluginsExplorerController extends Controller {
   }
 
   @action
-  resetParams() {
-    this.selectedItem.resetParams();
-  }
-
-  @action
   updateSortProperty(property) {
     if (this.sortByProperty === property) {
       this.sortDescending = !this.sortDescending;

--- a/assets/javascripts/discourse/templates/admin/plugins-explorer-queries-details.hbs
+++ b/assets/javascripts/discourse/templates/admin/plugins-explorer-queries-details.hbs
@@ -217,7 +217,7 @@
   <QueryResultsWrapper
     @results={{this.results}}
     @showResults={{this.showResults}}
-    @query={{this.selectedItem}}
+    @query={{this.model}}
     @content={{this.results}}
   />
 {{/if}}


### PR DESCRIPTION
## ✨ What's This?

This is a follow-up to #356.

The previous PR missed changing the name of the query object when passing it to `QueryResultsWrapper`, which resulted in the download links not working properly after a query was run.

This change fixes that bug, and includes an acceptance test to ensure it stays fixed during future work on this plugin.

## 👑 Testing

- Visit `/admin/plugins/explorer`
- Click on any query.
- Click the **Run** button.
- Click the **CSV** and **JSON** buttons, make sure the download happens as expected.