### PR TITLE
FIX: Ensure dates passed in query params are parsed in the local timezone.

### DIFF
--- a/assets/javascripts/discourse/components/param-input-form.gjs
+++ b/assets/javascripts/discourse/components/param-input-form.gjs
@@ -222,7 +222,7 @@ export default class ParamInputForm extends Component {
           if (!value) {
             return null;
           }
-          return moment(new Date(value).toISOString()).format("YYYY-MM-DD");
+          return moment(value).format("YYYY-MM-DD");
         } catch {
           this.addError(info.identifier, ERRORS.INVALID_DATE(String(value)));
           return null;


### PR DESCRIPTION
## ✨ What's This?

When passing date values for reports as URL parameters, they were being parsed by the standard JavaScript `Date` object, which due to legacy reasons parses date-only strings in UTC, all other date formats are assumed to be in the browser's local timezone.

This change switches to using `moment`'s parser, which assumes that all strings passed to it are in the browser's local timezone.

## 👑 Testing

- Change your computer to be in a timezone with a different date to the current UTC date.
- Visit a group report that requires a date parameter. Select a date, and run the report.
- Copy the current URL into a new tab, and confirm that the date displayed stays the same.