### PR TITLE
DEV: update deprecated icon fa-user in test

### DIFF
--- a/test/javascripts/integration/components/query-result-test.gjs
+++ b/test/javascripts/integration/components/query-result-test.gjs
@@ -55,7 +55,7 @@ module(
           badge: [
             {
               description: "description",
-              icon: "fa-user",
+              icon: "user",
               id: 1,
               name: "badge name",
               display_name: "badge display name",


### PR DESCRIPTION
This PR does an update for deprecated icon names. For more detail, refer to the announcement at https://meta.discourse.org/t/-/325349.