### PR TITLE
FIX: allow query to be explained

### DIFF
--- a/app/controllers/discourse_data_explorer/query_controller.rb
+++ b/app/controllers/discourse_data_explorer/query_controller.rb
@@ -194,6 +194,7 @@ module ::DiscourseDataExplorer
                        result,
                        query_params:,
                        download: params[:download],
+                       explain: params[:explain] == "true",
                      )
           end
           format.csv do


### PR DESCRIPTION
Bug introduced during refactoring in this PR: https://github.com/discourse/discourse-data-explorer/pull/318

Explain parameter must be passed to `ResultFormatConverter`.

![Screenshot 2025-04-23 at 1 39 54 pm](https://github.com/user-attachments/assets/451591aa-0975-48f4-848c-50affa414885)
