### PR TITLE
FIX: edit button not working

### DIFF
--- a/assets/javascripts/discourse/templates/admin/plugins-explorer-queries-details.gjs
+++ b/assets/javascripts/discourse/templates/admin/plugins-explorer-queries-details.gjs
@@ -61,13 +61,11 @@ export default RouteTemplate(
             <h1>
               {{@controller.model.name}}
               {{#unless @controller.editDisabled}}
-                <a
-                  href
-                  {{on "click" @controller.editName}}
-                  class="edit-query-name"
-                >
-                  {{icon "pencil"}}
-                </a>
+                <DButton
+                  @action={{@controller.editName}}
+                  @icon="pencil"
+                  class="edit-query-name btn-transparent"
+                />
               {{/unless}}
             </h1>
           </div>

--- a/assets/stylesheets/explorer.scss
+++ b/assets/stylesheets/explorer.scss
@@ -215,7 +215,7 @@ table.group-reports {
       margin: 0 0.5em 0 0;
       color: var(--primary);
 
-      a {
+      button .d-icon {
         color: currentcolor;
       }
     }

--- a/spec/system/explorer_spec.rb
+++ b/spec/system/explorer_spec.rb
@@ -27,6 +27,15 @@ RSpec.describe "Explorer", type: :system, js: true do
 
       expect(page).to have_field("limit", with: 42)
     end
+
+    it "allows to edit custom name" do
+      visit("/admin/plugins/explorer/queries/#{query_1.id}")
+      find(".query-run .btn-primary").click
+      find(".edit-query-name").click
+      find(".name-text-field input").fill_in(with: "My custom name edited")
+      find(".btn-primary").click
+      find("button span", text: "Save Changes and Run").click
+    end
   end
 
   context "with the old url format" do


### PR DESCRIPTION
After this PR <a> link stopped working correctly page started doing a full reload. <Button> component behaves correctly.

https://github.com/discourse/discourse-data-explorer/pull/376


https://github.com/user-attachments/assets/9799d18e-d430-45bd-9eff-f5d75c4e0962

