### PR TITLE
FIX: Don't add `only: nil` serializing options of data explorer results

### DIFF
--- a/lib/discourse_data_explorer/data_explorer.rb
+++ b/lib/discourse_data_explorer/data_explorer.rb
@@ -198,11 +198,9 @@ module ::DiscourseDataExplorer
             .includes(support_info[:include])
             .order(:id)
 
-        ret[cls] = ActiveModel::ArraySerializer.new(
-          all_objs,
-          each_serializer: support_info[:serializer],
-          only: support_info[:only],
-        )
+        opts = { each_serializer: support_info[:serializer] }
+        opts[:only] = support_info[:only] if support_info[:only]
+        ret[cls] = ActiveModel::ArraySerializer.new(all_objs, **opts)
       end
       [ret, col_map]
     end

--- a/spec/data_explorer_spec.rb
+++ b/spec/data_explorer_spec.rb
@@ -100,6 +100,9 @@ describe DiscourseDataExplorer::DataExplorer do
             records = relations[:topic].object
             records.map { |t| BasicTopicSerializer.new(t, root: false).as_json }
           }.not_to raise_error
+
+          json = relations[:topic].as_json
+          expect(json).to include(BasicTopicSerializer.new(topic, root: false).as_json)
         end
 
         it "chooses the correct serializer for tag_group" do


### PR DESCRIPTION
`only: nil` will cause ArraySerializer to overwrite the default Serializer settings, which will cause Topic, Post, etc. to be serialized as empty `{}`. We need to exclude the configuration without only.

The current test case only ensures that no error is raised, but does not guarantee the accuracy of the result, which indirectly introduces this bug. Additional tests are added to ensure consistent results.